### PR TITLE
New bin class

### DIFF
--- a/docs/sphinx/api/tools.rst
+++ b/docs/sphinx/api/tools.rst
@@ -25,6 +25,17 @@ Plate
    :show-inheritance:
 
 
+.. _marvin-tools-bin:
+
+Bin
+---
+
+.. automodule:: marvin.tools.bin
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. _marvin-tools-spaxel:
 
 Spaxel
@@ -77,6 +88,14 @@ Map
 ---
 
 .. automodule:: marvin.tools.map
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Model Cube
+----------
+
+.. automodule:: marvin.tools.modelcube
    :members:
    :undoc-members:
    :show-inheritance:

--- a/python/marvin/__init__.py
+++ b/python/marvin/__init__.py
@@ -33,6 +33,7 @@ log = initLog(logFilePath)
 
 warnings.simplefilter('once')
 warnings.filterwarnings('ignore', 'Skipped unsupported reflection of expression-based index')
+warnings.filterwarnings('ignore', '(.)+size changed, may indicate binary incompatibility(.)+')
 
 
 class MarvinConfig(object):

--- a/python/marvin/api/maps.py
+++ b/python/marvin/api/maps.py
@@ -158,3 +158,41 @@ class MapsView(marvin.api.base.BaseView):
             self.results['error'] = 'Failed to parse input name {0}: {1}'.format(name, str(ee))
 
         return json.dumps(self.results)
+
+    @flask_classy.route('/<name>/<bintype>/<template_kin>/spaxels/<binid>',
+                        methods=['GET', 'POST'], endpoint='getbinspaxels')
+    def getBinSpaxels(self, name, bintype, template_kin, binid):
+        """Returns a list of x and y indices for spaxels belonging to ``binid``.
+
+        Parameters:
+            name (str):
+                The ``plateifu`` or ``mangaid`` of the object.
+            bintype (str):
+                The bintype associated with this model cube. If not defined,
+                the default type of binning will be used.
+            template_kin (str):
+                The template_kin associated with this model cube.
+                If not defined, the default template_kin will be used.
+            binid (int):
+                The binid to which the spaxels belong.
+
+        e.g., https://api.sdss.org/marvin2/api/maps/8485-1901/SPX/GAU-MILESHC/spaxels/112/
+
+        """
+
+        kwargs = {'bintype': bintype, 'template_kin': template_kin}
+
+        # Initialises the Maps object
+        maps, results = _getMaps(name, **kwargs)
+        self.update_results(results)
+
+        if maps is None:
+            return json.dumps(self.results)
+
+        try:
+            self.results['data'] = {}
+        except Exception as ee:
+            self.results['error'] = ('Failed to get spaxels for binid={0}: {1}'
+                                     .format(binid, str(ee)))
+
+        return json.dumps(self.results)

--- a/python/marvin/api/maps.py
+++ b/python/marvin/api/maps.py
@@ -191,6 +191,7 @@ class MapsView(marvin.api.base.BaseView):
 
         try:
             self.results['data'] = {}
+            self.results['data']['spaxels'] = maps.get_bin_spaxels(binid, only_list=True)
         except Exception as ee:
             self.results['error'] = ('Failed to get spaxels for binid={0}: {1}'
                                      .format(binid, str(ee)))

--- a/python/marvin/api/spaxel.py
+++ b/python/marvin/api/spaxel.py
@@ -92,9 +92,9 @@ class SpaxelView(BaseView):
 
         return json.dumps(self.results)
 
-    @route('/<name>/properties/<bintype>/<template_kin>/<x>/<y>/',
+    @route('/<name>/properties/<template_kin>/<x>/<y>/',
            methods=['GET', 'POST'], endpoint='getProperties')
-    def properties(self, name, x, y, bintype, template_kin):
+    def properties(self, name, x, y, template_kin):
         """Returns a dictionary with the DAP properties for a spaxel.
 
         Loads a DAP Maps and uses getSpaxel to retrieve the ``(x,y)``
@@ -105,9 +105,6 @@ class SpaxelView(BaseView):
                 The ``plateifu`` or ``mangaid`` of the object.
             x,y (int):
                 The x/y coordinates of the spaxel (origin is ``lower``).
-            bintype (str):
-                The bintype associated with this model cube. If not defined,
-                the default type of binning will be used.
             template_kin (str):
                 The template_kin associated with this model cube.
                 If not defined, the default template_kin will be used.
@@ -115,7 +112,6 @@ class SpaxelView(BaseView):
         """
 
         spaxel, results = _getSpaxel(name, int(x), int(y),
-                                     bintype=bintype,
                                      template_kin=template_kin,
                                      cube=False, modelcube=False)
 
@@ -133,9 +129,9 @@ class SpaxelView(BaseView):
 
         return json.dumps(self.results)
 
-    @route('/<name>/models/<bintype>/<template_kin>/<x>/<y>/',
+    @route('/<name>/models/<template_kin>/<x>/<y>/',
            methods=['GET', 'POST'], endpoint='getModels')
-    def getModels(self, name, x, y, bintype, template_kin):
+    def getModels(self, name, x, y, template_kin):
         """Returns a dictionary with the models for a spaxel.
 
         Loads a ModelCube and uses getSpaxel to retrieve the ``(x,y)``
@@ -146,9 +142,6 @@ class SpaxelView(BaseView):
                 The ``plateifu`` or ``mangaid`` of the object.
             x,y (int):
                 The x/y coordinates of the spaxel (origin is ``lower``).
-            bintype (str):
-                The bintype associated with this model cube. If not defined,
-                the default type of binning will be used.
             template_kin (str):
                 The template_kin associated with this model cube.
                 If not defined, the default template_kin will be used.
@@ -156,7 +149,6 @@ class SpaxelView(BaseView):
         """
 
         spaxel, results = _getSpaxel(name, x, y,
-                                     bintype=bintype,
                                      template_kin=template_kin,
                                      cube=False, maps=False)
 

--- a/python/marvin/tests/tools/test_bin.py
+++ b/python/marvin/tests/tools/test_bin.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# test_bin.py
+#
+# Created by José Sánchez-Gallego on 6 Nov 2016.
+
+
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+import os
+
+import marvin
+import marvin.tests
+import marvin.tools.bin
+import marvin.tools.maps
+import marvin.tools.modelcube
+
+
+class TestBinBase(marvin.tests.MarvinTest):
+    """Defines the files and plateifus we will use in the tests."""
+
+    @classmethod
+    def setUpClass(cls):
+
+        marvin.config.switchSasUrl('local')
+
+        cls.drpver = 'v2_0_1'
+        cls.dapver = '2.0.2'
+        cls.bintype = 'VOR10'
+
+        cls.plate = 8485
+        cls.mangaid = '1-209232'
+        cls.plateifu = '8485-1901'
+        cls.ifu = cls.plateifu.split('-')[1]
+
+        cls.maps_filename = os.path.join(
+            os.getenv('MANGA_SPECTRO_ANALYSIS'), cls.drpver, cls.dapver,
+            '{0}-GAU-MILESHC'.format(cls.bintype), str(cls.plate), str(cls.ifu),
+            'manga-{0}-{1}-{2}-GAU-MILESHC.fits.gz'.format(cls.plateifu, 'MAPS', cls.bintype))
+
+        cls.modelcube_filename = os.path.join(
+            os.getenv('MANGA_SPECTRO_ANALYSIS'), cls.drpver, cls.dapver,
+            '{0}-GAU-MILESHC'.format(cls.bintype), str(cls.plate), str(cls.ifu),
+            'manga-{0}-{1}-{2}-GAU-MILESHC.fits.gz'.format(cls.plateifu, 'LOGCUBE', cls.bintype))
+
+        cls.marvindb_session = marvin.marvindb.session
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def setUp(self):
+
+        marvin.marvindb.session = self.marvindb_session
+        marvin.config.setMPL('MPL-5')
+
+        self.assertTrue(os.path.exists(self.maps_filename))
+        self.assertTrue(os.path.exists(self.modelcube_filename))
+
+    def tearDown(self):
+        pass
+
+
+class TestBinInit(TestBinBase):
+
+    def _check_bin_data(self, bb):
+
+        self.assertEqual(bb.binid, 100)
+        self.assertEqual(bb.plateifu, self.plateifu)
+        self.assertEqual(bb.mangaid, self.mangaid)
+
+        self.assertTrue(len(bb.spaxels) == 2)
+        self.assertFalse(bb.spaxels[0].loaded)
+
+        self.assertIsNotNone(bb.properties)
+
+    def test_init_from_files(self):
+
+        bb = marvin.tools.bin.Bin(binid=100, maps_filename=self.maps_filename,
+                                  modelcube_filename=self.modelcube_filename)
+
+        self.assertIsInstance(bb._maps, marvin.tools.maps.Maps)
+        self.assertIsInstance(bb._modelcube, marvin.tools.modelcube.ModelCube)
+
+        self._check_bin_data(bb)
+
+    def test_init_from_file_only_maps(self):
+
+        bb = marvin.tools.bin.Bin(binid=100, maps_filename=self.maps_filename)
+
+        self.assertIsInstance(bb._maps, marvin.tools.maps.Maps)
+        self.assertFalse(bb._modelcube)
+
+        self._check_bin_data(bb)
+
+    def test_init_from_db(self):
+
+        bb = marvin.tools.bin.Bin(binid=100, plateifu=self.plateifu, bintype=self.bintype)
+        self.assertIsInstance(bb._maps, marvin.tools.maps.Maps)
+        self.assertIsInstance(bb._modelcube, marvin.tools.modelcube.ModelCube)
+
+        self._check_bin_data(bb)
+
+    def test_init_from_api(self):
+
+        bb = marvin.tools.bin.Bin(binid=100, plateifu=self.plateifu, mode='remote',
+                                  bintype=self.bintype)
+
+        self.assertIsInstance(bb._maps, marvin.tools.maps.Maps)
+        self.assertIsInstance(bb._modelcube, marvin.tools.modelcube.ModelCube)
+
+        self._check_bin_data(bb)

--- a/python/marvin/tests/tools/test_maps.py
+++ b/python/marvin/tests/tools/test_maps.py
@@ -125,6 +125,19 @@ class TestMapsFile(TestMapsBase):
         self.assertIsNotNone(spaxel.spectrum)
         self.assertTrue(len(spaxel.properties.keys()) > 0)
 
+    def test_get_spaxel_binned_maps(self):
+
+        maps = marvin.tools.maps.Maps(plateifu=self.plateifu, bintype='VOR10',
+                                      release='MPL-5')
+        spaxel = maps.getSpaxel(x=15, y=8, xyorig='lower')
+
+        self.assertTrue(isinstance(spaxel, marvin.tools.spaxel.Spaxel))
+        self.assertIsNotNone(spaxel.spectrum)
+        self.assertTrue(len(spaxel.properties.keys()) > 0)
+
+        self.assertAlmostEqual(spaxel.properties['stellar_vel'].ivar, 0.00031520479546875247)
+        self.assertEqual(spaxel.bintype, 'SPX')
+
 
 class TestMapsDB(TestMapsBase):
 

--- a/python/marvin/tests/tools/test_spaxel.py
+++ b/python/marvin/tests/tools/test_spaxel.py
@@ -212,6 +212,16 @@ class TestSpaxelInit(TestSpaxelBase):
         self.assertTrue(len(spaxel.properties) > 0)
         self.assertIsInstance(spaxel.properties, DictOfProperties)
 
+    def test_fails_unbinned_maps(self):
+
+        maps = marvin.tools.maps.Maps(plateifu=self.plateifu, bintype='VOR10',
+                                      release='MPL-5')
+
+        with self.assertRaises(MarvinError) as cm:
+            Spaxel(x=15, y=16, plateifu=self.plateifu, maps=maps)
+
+        self.assertIn('cannot instantiate a Spaxel from a binned Maps.', str(cm.exception))
+
 
 class TestPickling(TestSpaxelBase):
 

--- a/python/marvin/tests/tools/test_spaxel.py
+++ b/python/marvin/tests/tools/test_spaxel.py
@@ -192,6 +192,26 @@ class TestSpaxelInit(TestSpaxelBase):
                    template_kin='MILES-TH')
         self.assertIn('invalid template_kin', str(cm.exception))
 
+    def test_load_false(self):
+
+        spaxel = Spaxel(plateifu=self.plateifu, x=15, y=16, load=False)
+
+        self.assertFalse(spaxel.loaded)
+        self.assertTrue(spaxel.cube)
+        self.assertTrue(spaxel.maps)
+        self.assertTrue(spaxel.modelcube)
+        self.assertEqual(len(spaxel.properties), 0)
+        self.assertIsNone(spaxel.spectrum)
+
+        spaxel.load()
+
+        self.assertIsInstance(spaxel.cube, marvin.tools.cube.Cube)
+        self.assertIsInstance(spaxel.maps, marvin.tools.maps.Maps)
+
+        self.assertIsInstance(spaxel.spectrum, Spectrum)
+        self.assertTrue(len(spaxel.properties) > 0)
+        self.assertIsInstance(spaxel.properties, DictOfProperties)
+
 
 class TestPickling(TestSpaxelBase):
 

--- a/python/marvin/tools/analysis_props.py
+++ b/python/marvin/tools/analysis_props.py
@@ -66,5 +66,5 @@ class AnalysisProperty(object):
 
     def __repr__(self):
 
-        return ('<AnalysisProperty ({0.name}, {0.channel}, value={0.value} '
+        return ('<AnalysisProperty (name={0.name}, channels={0.channel}, value={0.value} '
                 'ivar={0.ivar}, mask={0.mask})>'.format(self))

--- a/python/marvin/tools/bin.py
+++ b/python/marvin/tools/bin.py
@@ -19,6 +19,48 @@ from marvin.tools.spaxel import Spaxel
 
 
 class Bin(object):
+    """A class to interface with a bin.
+
+    This class represents a bin of spaxels in a MaNGA DAP
+    `:class:~marvin.tools.maps.Maps` or
+    `:class:~marvin.tools.modelcube.ModelCube`.
+    By definition, a bin is identified by a ``binid`` and can correspond to a
+    binned or unbinned MAPS, although in the latter case there is no formal
+    difference between a bin and a spaxel.
+
+    When a bin is instantiated, a list of its contituent
+    `:class:~marvin.tools.spaxel.Spaxel` is created. ``Spaxel`` objects are
+    created unloaded for efficiency, but they can be loaded by doing, for
+    example for the first spaxel, ``bin.spaxels[0].load()``.
+
+    MAPS properties and (if available) Model Cube spectra are loaded for the
+    bin.
+
+    Parameters:
+        binid (int):
+            The binid of the requested bin.
+        extra_kwargs:
+            Any other keyword parameter necessary to instantiate the
+            `:class:~marvin.tools.maps.Maps`, the
+            `:class:~marvin.tools.modelcube.ModelCube`, or the
+            `:class:~marvin.tools.spaxel.Spaxel` related to this bin. Refer to
+            the documentation of those classes for details on the available
+            keywords.
+
+    Attributes:
+        spaxels (list):
+            A list of `:class:~marvin.tools.spaxel.Spaxel` objects that form
+            the bin. The spaxels are created unloaded.
+        properties (dict):
+            Same as the `:class:~marvin.tools.maps.Maps` properties for a
+            given spaxel, but in this case for the bin.
+        modelcube_attributes:
+            All the attributes derived for a given spaxel from the
+            `:class:~marvin.tools.modelcube.ModelCube`, but in this case for
+            the bin. If a modelcube is not available or it is not instantiated,
+            these attributes will be ``None``.
+
+    """
 
     def __init__(self, binid, **kwargs):
 

--- a/python/marvin/tools/bin.py
+++ b/python/marvin/tools/bin.py
@@ -113,3 +113,11 @@ class Bin(object):
         self.emline = sample_spaxel.emline
         self.emline_base = sample_spaxel.emline_base
         self.stellar_continuum = sample_spaxel.stellar_continuum
+
+    def load_all(self):
+        """Loads all the spaxels that for this bin."""
+
+        for spaxel in self.spaxels:
+            spaxel.load()
+
+        return

--- a/python/marvin/tools/bin.py
+++ b/python/marvin/tools/bin.py
@@ -54,13 +54,15 @@ class Bin(object):
     def _load_spaxels(self, **kwargs):
         """Creates a list of unloaded spaxels for this binid."""
 
+        load_spaxels = kwargs.pop('load_spaxels', False)
+
         self.spaxel_coords = self._maps.get_bin_spaxels(self.binid, only_list=True)
 
         if len(self.spaxel_coords) == 0:
             raise MarvinError('there are no spaxels associated with binid={0}.'.format(self.binid))
         else:
             self.spaxels = [Spaxel(x=cc[0], y=cc[1], cube=True, maps=self._maps,
-                                   modelcube=self._modelcube, load=False, **kwargs)
+                                   modelcube=self._modelcube, load=load_spaxels, **kwargs)
                             for cc in self.spaxel_coords]
 
     def _load_data(self, **kwargs):

--- a/python/marvin/tools/bin.py
+++ b/python/marvin/tools/bin.py
@@ -22,6 +22,9 @@ class Bin(object):
 
     def __init__(self, binid, **kwargs):
 
+        self.plateifu = None
+        self.mangaid = None
+
         self._maps, self._modelcube = self._get_dap_objects(**kwargs)
         self.binid = binid
 
@@ -38,6 +41,9 @@ class Bin(object):
             maps = Maps(**kwargs)
         except MarvinError as ee:
             raise MarvinError('failed to open a Maps: {0}'.format(str(ee)))
+
+        self.plateifu = self._maps.plateifu
+        self.mangaid = self._maps.mangaid
 
         if _is_MPL4(maps._dapver):
             return maps, None

--- a/python/marvin/tools/bin.py
+++ b/python/marvin/tools/bin.py
@@ -22,14 +22,14 @@ class Bin(object):
     """A class to interface with a bin.
 
     This class represents a bin of spaxels in a MaNGA DAP
-    `:class:~marvin.tools.maps.Maps` or
-    `:class:~marvin.tools.modelcube.ModelCube`.
+    :class:`~marvin.tools.maps.Maps` or
+    :class:`~marvin.tools.modelcube.ModelCube`.
     By definition, a bin is identified by a ``binid`` and can correspond to a
     binned or unbinned MAPS, although in the latter case there is no formal
     difference between a bin and a spaxel.
 
     When a bin is instantiated, a list of its contituent
-    `:class:~marvin.tools.spaxel.Spaxel` is created. ``Spaxel`` objects are
+    :class:`~marvin.tools.spaxel.Spaxel` is created. ``Spaxel`` objects are
     created unloaded for efficiency, but they can be loaded by doing, for
     example for the first spaxel, ``bin.spaxels[0].load()``.
 
@@ -41,22 +41,22 @@ class Bin(object):
             The binid of the requested bin.
         extra_kwargs:
             Any other keyword parameter necessary to instantiate the
-            `:class:~marvin.tools.maps.Maps`, the
-            `:class:~marvin.tools.modelcube.ModelCube`, or the
-            `:class:~marvin.tools.spaxel.Spaxel` related to this bin. Refer to
+            :class:`~marvin.tools.maps.Maps`, the
+            :class:`~marvin.tools.modelcube.ModelCube`, or the
+            :class:`~marvin.tools.spaxel.Spaxel` related to this bin. Refer to
             the documentation of those classes for details on the available
             keywords.
 
     Attributes:
         spaxels (list):
-            A list of `:class:~marvin.tools.spaxel.Spaxel` objects that form
+            A list of :class:`~marvin.tools.spaxel.Spaxel` objects that form
             the bin. The spaxels are created unloaded.
         properties (dict):
-            Same as the `:class:~marvin.tools.maps.Maps` properties for a
+            Same as the :class:`~marvin.tools.maps.Maps` properties for a
             given spaxel, but in this case for the bin.
         modelcube_attributes:
             All the attributes derived for a given spaxel from the
-            `:class:~marvin.tools.modelcube.ModelCube`, but in this case for
+            :class:`~marvin.tools.modelcube.ModelCube`, but in this case for
             the bin. If a modelcube is not available or it is not instantiated,
             these attributes will be ``None``.
 

--- a/python/marvin/tools/bin.py
+++ b/python/marvin/tools/bin.py
@@ -61,8 +61,11 @@ class Bin(object):
         if len(self.spaxel_coords) == 0:
             raise MarvinError('there are no spaxels associated with binid={0}.'.format(self.binid))
         else:
-            self.spaxels = [Spaxel(x=cc[0], y=cc[1], cube=True, maps=self._maps,
-                                   modelcube=self._modelcube, load=load_spaxels, **kwargs)
+            modelcube_for_spaxel = False if not self._modelcube else self._modelcube.get_unbinned()
+            kwargs_copy = kwargs.copy()
+            kwargs_copy.pop('bintype', None)
+            self.spaxels = [Spaxel(x=cc[0], y=cc[1], cube=True, maps=self._maps.get_unbinned(),
+                                   modelcube=modelcube_for_spaxel, load=load_spaxels, **kwargs_copy)
                             for cc in self.spaxel_coords]
 
     def _load_data(self, **kwargs):
@@ -73,7 +76,7 @@ class Bin(object):
         sample_coords = self.spaxel_coords[0]
         sample_spaxel = Spaxel(x=sample_coords[0], y=sample_coords[1],
                                cube=True, maps=self._maps, modelcube=self._modelcube,
-                               load=True, **kwargs)
+                               load=True, allow_binned=True, **kwargs)
 
         self.specres = sample_spaxel.specres
         self.specresd = sample_spaxel.specresd

--- a/python/marvin/tools/bin.py
+++ b/python/marvin/tools/bin.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# encoding: utf-8
+#
+# bin.py
+#
+# Created by José Sánchez-Gallego on 6 Nov 2016.
+
+
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+import warnings
+
+from marvin.core.exceptions import MarvinError, MarvinUserWarning
+from marvin.tools.maps import Maps, _is_MPL4
+from marvin.tools.modelcube import ModelCube
+from marvin.tools.spaxel import Spaxel
+
+
+class Bin(object):
+
+    def __init__(self, binid, **kwargs):
+
+        self._maps, self._modelcube = self._get_dap_objects(**kwargs)
+        self.binid = binid
+
+        spaxel_coords = self._maps.get_bin_spaxels(binid, only_list=True)
+
+        if len(spaxel_coords) == 0:
+            self.spaxels = []
+        else:
+            self.spaxels = [Spaxel(x=cc[0], y=cc[1], cube=True, maps=self._maps,
+                                   modelcube=self._modelcube, load=False, **kwargs)
+                            for cc in spaxel_coords]
+
+    def _get_dap_objects(self, **kwargs):
+        """Gets the Maps and ModelCube object."""
+
+        try:
+            maps = Maps(**kwargs)
+        except MarvinError as ee:
+            raise MarvinError('failed to open a Maps: {0}'.format(str(ee)))
+
+        if _is_MPL4(maps._dapver):
+            return maps, None
+
+        try:
+            modelcube = ModelCube(**kwargs)
+        except MarvinError:
+            warnings.warn('cannot open a ModelCube for this combination of '
+                          'parameters. Some fetures will not be available.', MarvinUserWarning)
+            modelcube = False
+
+        return maps, modelcube

--- a/python/marvin/tools/maps.py
+++ b/python/marvin/tools/maps.py
@@ -560,16 +560,19 @@ class Maps(marvin.core.core.MarvinToolsClass):
         """
 
         if self.data_origin == 'file':
-            spaxel_coords = zip(*np.where(self.data['BINID'].T == binid))
+            spaxel_coords = zip(*np.where(self.data['BINID'].data.T == binid))
 
         elif self.data_origin == 'db':
             mdb = marvin.marvindb
-            spaxel_coords = mdb.session.query(mdb.dapdb.SpaxelProp5.x,
-                                              mdb.dapdb.SpaxelProp5.y).join(mdb.dapdb.File).filter(
-                mdb.dapdb.SpaxelProp5.binid == 100,
-                mdb.dapdb.File.pk == self.data.pk).order_by(
-                    mdb.dapdb.SpaxelProp5.x,
-                    mdb.dapdb.SpaxelProp5.y).all()
+
+            if _is_MPL4(self._dapver):
+                table = mdb.dapdb.SpaxelProp
+            else:
+                table = mdb.dapdb.SpaxelProp5
+
+            spaxel_coords = mdb.session.query(table.x, table.y).join(mdb.dapdb.File).filter(
+                table.binid == binid, mdb.dapdb.File.pk == self.data.pk).order_by(
+                    table.x, table.y).all()
 
         elif self.data_origin == 'api':
             url = marvin.config.urlmap['api']['getbinspaxels']['url']
@@ -587,7 +590,7 @@ class Maps(marvin.core.core.MarvinToolsClass):
                     .format(binid, str(ee)))
 
             response = response.getData()
-            spaxel_coords = response['spaxel']
+            spaxel_coords = response['spaxels']
 
         if len(spaxel_coords) == 0:
             if only_list:

--- a/python/marvin/tools/modelcube.py
+++ b/python/marvin/tools/modelcube.py
@@ -98,7 +98,7 @@ class ModelCube(MarvinToolsClass):
         if kwargs.pop('template_pop', None):
             warnings.warn('template_pop is not yet in use. Ignoring value.', MarvinUserWarning)
 
-        self.bintype = kwargs.pop('bintype', marvin.tools.maps.__BINTYPES_DEFAULT__)
+        self.bintype = kwargs.pop('bintype', marvin.tools.maps.__BINTYPES_UNBINNED__)
         self.template_kin = kwargs.pop('template_kin', marvin.tools.maps.__TEMPLATES_KIN_DEFAULT__)
         self.template_pop = None
 
@@ -335,8 +335,8 @@ class ModelCube(MarvinToolsClass):
         """
 
         kwargs['cube'] = self.cube if spectrum else False
-        kwargs['maps'] = self.maps if properties else False
-        kwargs['modelcube'] = self
+        kwargs['maps'] = self.maps.get_unbinned() if properties else False
+        kwargs['modelcube'] = self.get_unbinned()
 
         return marvin.utils.general.general.getSpaxel(x=x, y=y, ra=ra, dec=dec, **kwargs)
 
@@ -427,3 +427,26 @@ class ModelCube(MarvinToolsClass):
                                                 release=self._release)
 
         return self._maps
+
+    def is_binned(self):
+        """Returns True if the ModelCube is not unbinned."""
+
+        if marvin.tools.maps._is_MPL4(self._dapver):
+            return self.bintype != marvin.tools.maps.__BINTYPES_MPL4_UNBINNED__
+        else:
+            return self.bintype != marvin.tools.maps.__BINTYPES_UNBINNED__
+
+    def get_unbinned(self):
+        """Returns a version of ``self`` corresponding to the unbinned ModelCube."""
+
+        if marvin.tools.maps._is_MPL4(self._dapver):
+            unbinned_name = marvin.tools.maps.__BINTYPES_MPL4_UNBINNED__
+        else:
+            unbinned_name = marvin.tools.maps.__BINTYPES_UNBINNED__
+
+        if self.bintype == unbinned_name:
+            return self
+        else:
+            return ModelCube(plateifu=self.plateifu, release=self._release, bintype=unbinned_name,
+                             template_kin=self.template_kin, template_pop=self.template_pop,
+                             mode=self.mode)

--- a/python/marvin/tools/spaxel.py
+++ b/python/marvin/tools/spaxel.py
@@ -252,6 +252,9 @@ class Spaxel(object):
     def load(self):
         """Loads the spaxel data."""
 
+        if self.loaded:
+            return
+
         self._check_cube()
         self._check_maps()
         self._check_modelcube()

--- a/python/marvin/tools/spaxel.py
+++ b/python/marvin/tools/spaxel.py
@@ -75,11 +75,6 @@ class Spaxel(object):
             ``Spaxel.stellar_continuum`` from the corresponding
             spaxel of the DAP modelcube that matches ``bintype``,
             ``template_kin``, and ``template_pop``.
-        bintype (str or None):
-            The binning type. For MPL-4, one of the following: ``'NONE',
-            'RADIAL', 'STON'`` (if ``None`` defaults to ``'NONE'``).
-            For MPL-5 and successive, one of, ``'ALL', 'NRE', 'SPX', 'VOR10'``
-            (defaults to ``'ALL'``).
         template_kin (str or None):
             The template use for kinematics. For MPL-4, one of
             ``'M11-STELIB-ZSOL', 'MILES-THIN', 'MIUSCAT-THIN'`` (if ``None``,
@@ -135,7 +130,7 @@ class Spaxel(object):
 
         valid_kwargs = [
             'x', 'y', 'cube_filename', 'maps_filename', 'modelcube_filename',
-            'mangaid', 'plateifu', 'cube', 'maps', 'modelcube', 'bintype',
+            'mangaid', 'plateifu', 'cube', 'maps', 'modelcube',
             'template_kin', 'template_pop', 'release', 'load']
 
         assert len(args) == 0, 'Spaxel does not accept arguments, only keywords.'
@@ -331,12 +326,15 @@ class Spaxel(object):
             self.maps = marvin.tools.maps.Maps(filename=self.__maps_filename,
                                                mangaid=self.mangaid,
                                                plateifu=self.plateifu,
-                                               bintype=self.bintype,
                                                template_kin=self.template_kin,
                                                release=self._release)
         else:
             self.maps = None
             return
+
+        # Checks the bintype
+        if self.maps.is_binned():
+            raise MarvinError('cannot instantiate a Spaxel from a binned Maps.')
 
         if self.plateifu is not None:
             assert self.plateifu == self.maps.plateifu, \
@@ -375,12 +373,15 @@ class Spaxel(object):
             self.modelcube = marvin.tools.modelcube.ModelCube(filename=self.__modelcube_filename,
                                                               mangaid=self.mangaid,
                                                               plateifu=self.plateifu,
-                                                              bintype=self.bintype,
                                                               template_kin=self.template_kin,
                                                               release=self._release)
         else:
             self.modelcube = None
             return
+
+        # Checks the bintype
+        if self.modelcube.is_binned():
+            raise MarvinError('cannot instantiate a Spaxel from a binned ModelCube.')
 
         self.bintype = self.modelcube.bintype
         self.template_kin = self.modelcube.template_kin


### PR DESCRIPTION
This pull request includes changes to `Spaxel` and implements the new `Bin` class. `Spaxel` has now been modified to only represent spaxels from unbinned maps/modelcubes. This can be overridden using the `allow_binned=True` parameter, but it's not the default behaviour. This change does not seem to have broken anything, but any additional test would be good, as a fair amount of things depend on `Spaxel`.

`Bin` is still a pretty basic implementation but it contains all the critical bits, and can be extended after the beta release.