### PR TITLE
Adds NSA information to MarvinToolsClass derivates

### DIFF
--- a/python/marvin/api/general.py
+++ b/python/marvin/api/general.py
@@ -16,10 +16,13 @@ Revision history:
 
 from __future__ import division
 from __future__ import print_function
+
+import json
 from flask_classy import route
+
 from brain.api.general import BrainGeneralRequestsView
 from marvin.utils.general import mangaid2plateifu as mangaid2plateifu
-import json
+from marvin.utils.general import get_nsa_data
 
 
 class GeneralRequestsView(BrainGeneralRequestsView):
@@ -34,5 +37,37 @@ class GeneralRequestsView(BrainGeneralRequestsView):
         except Exception as ee:
             self.results['status'] = -1
             self.results['error'] = ('manga2plateifu failed with error: {0}'.format(str(ee)))
+
+        return json.dumps(self.results)
+
+    @route('/nsa/full/<mangaid>/', endpoint='nsa_full', methods=['GET', 'POST'])
+    def get_nsa_data(self, mangaid):
+        """Returns the NSA data for a given mangaid from the full catalogue."""
+
+        try:
+            nsa_data = get_nsa_data(mangaid, mode='local', source='nsa')
+            self.results['data'] = nsa_data
+            self.results['status'] = 1
+        except Exception as ee:
+            self.results['status'] = -1
+            self.results['error'] = 'get_nsa_data failed with error: {0}'.format(str(ee))
+
+        return json.dumps(self.results)
+
+    @route('/nsa/drpall/<mangaid>/', endpoint='nsa_drpall', methods=['GET', 'POST'])
+    def get_nsa_drpall_data(self, mangaid):
+        """Returns the NSA data in drpall for a given mangaid.
+
+        Note that this always uses the drpver/drpall versions that are default in the server.
+
+        """
+
+        try:
+            nsa_data = get_nsa_data(mangaid, mode='local', source='drpall')
+            self.results['data'] = nsa_data
+            self.results['status'] = 1
+        except Exception as ee:
+            self.results['status'] = -1
+            self.results['error'] = 'get_nsa_data failed with error: {0}'.format(str(ee))
 
         return json.dumps(self.results)

--- a/python/marvin/core/core.py
+++ b/python/marvin/core/core.py
@@ -26,7 +26,7 @@ import marvin_pickle
 
 from marvin.core.exceptions import MarvinUserWarning, MarvinError, MarvinMissingDependency
 from marvin.utils.db import testDbConnection
-from marvin.utils.general import mangaid2plateifu
+from marvin.utils.general import mangaid2plateifu, get_nsa_data
 
 try:
     from sdss_access.path import Path
@@ -78,6 +78,11 @@ class MarvinToolsClass(object):
         self._release = kwargsGet(kwargs, 'release', marvin.config.release)
         self._drpall = kwargsGet(kwargs, 'drpall', marvin.config.drpall)
         self._drpver, self._dapver = marvin.config.lookUpVersions(release=self._release)
+
+        self._nsa = None
+        self.nsa_source = kwargs.pop('nsa_source', 'auto')
+        assert self.nsa_source in ['auto', 'nsa', 'drpall'], \
+            'nsa_source must be one of auto, nsa, or drpall'
 
         self._forcedownload = kwargsGet(kwargs, 'download', marvin.config.download)
 
@@ -246,6 +251,27 @@ class MarvinToolsClass(object):
         """
 
         return marvin_pickle.restore(path, delete=delete)
+
+    @property
+    def nsa(self):
+        """Returns the contents of the NSA catalogue for this target."""
+
+        if self._nsa is None:
+
+            if self.nsa_source == 'auto':
+                if self.data_origin == 'file':
+                    nsa_source = 'drpall'
+                else:
+                    nsa_source = 'nsa'
+            else:
+                nsa_source = self.nsa_source
+
+            self._nsa = get_nsa_data(self.mangaid, mode='auto',
+                                     source=nsa_source,
+                                     drpver=self._drpver,
+                                     drpall=self._drpall)
+
+        return self._nsa
 
 
 class Dotable(dict):

--- a/python/marvin/tests/tools/test_cube.py
+++ b/python/marvin/tests/tools/test_cube.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import collections
 import os
 import unittest
 
@@ -177,6 +178,58 @@ class TestCube(TestCubeBase):
     def test_cube_remote_redshift(self):
         cube = Cube(plateifu=self.plateifu, mode='remote')
         self.assertAlmostEqual(cube.redshift, 0.0407447)
+
+    def _test_nsa(self, nsa_data, mode='nsa'):
+        self.assertIsInstance(nsa_data, collections.OrderedDict)
+        if mode == 'drpall':
+            self.assertNotIn('profmean_ivar', nsa_data.keys())
+        self.assertIn('zdist', nsa_data.keys())
+        self.assertAlmostEqual(nsa_data['zdist'], 0.041201399999999999)
+
+    def test_nsa_file_auto(self):
+        cube = Cube(filename=self.filename)
+        self.assertEqual(cube.nsa_source, 'auto')
+        self._test_nsa(cube.nsa)
+
+    def test_nsa_file_nsa(self):
+        cube = Cube(filename=self.filename, nsa_source='nsa')
+        self.assertEqual(cube.nsa_source, 'nsa')
+        self._test_nsa(cube.nsa)
+
+    def test_nsa_file_drpall(self):
+        cube = Cube(plateifu=self.plateifu, nsa_source='drpall')
+        self.assertEqual(cube.nsa_source, 'drpall')
+        self._test_nsa(cube.nsa)
+
+    def test_nsa_db_auto(self):
+        cube = Cube(plateifu=self.plateifu)
+        self.assertEqual(cube.nsa_source, 'auto')
+        self._test_nsa(cube.nsa)
+
+    def test_nsa_db_nsa(self):
+        cube = Cube(plateifu=self.plateifu, nsa_source='nsa')
+        self.assertEqual(cube.nsa_source, 'nsa')
+        self._test_nsa(cube.nsa)
+
+    def test_nsa_db_drpall(self):
+        cube = Cube(plateifu=self.plateifu, nsa_source='drpall')
+        self.assertEqual(cube.nsa_source, 'drpall')
+        self._test_nsa(cube.nsa)
+
+    def test_nsa_remote_auto(self):
+        cube = Cube(plateifu=self.plateifu, mode='remote')
+        self.assertEqual(cube.nsa_source, 'auto')
+        self._test_nsa(cube.nsa)
+
+    def test_nsa_remote_nsa(self):
+        cube = Cube(plateifu=self.plateifu, mode='remote', nsa_source='nsa')
+        self.assertEqual(cube.nsa_source, 'nsa')
+        self._test_nsa(cube.nsa)
+
+    def test_nsa_remote_drpall(self):
+        cube = Cube(plateifu=self.plateifu, mode='remote', nsa_source='drpall')
+        self.assertEqual(cube.nsa_source, 'drpall')
+        self._test_nsa(cube.nsa)
 
 
 class TestGetSpaxel(TestCubeBase):

--- a/python/marvin/tests/utils/test_general.py
+++ b/python/marvin/tests/utils/test_general.py
@@ -16,6 +16,7 @@ Revision history:
 from __future__ import division
 from __future__ import print_function
 
+from collections import OrderedDict
 from unittest import TestCase
 from astropy.io import fits
 from astropy.wcs import WCS
@@ -141,10 +142,12 @@ class TestGetNSAData(TestCase):
         marvin.config.db = self.config_db
 
     def _test_nsa(self, data):
+        self.assertIsInstance(data, OrderedDict)
         self.assertIn('profmean_ivar', data.keys())
         self.assertEqual(data['profmean_ivar'][0][0], 18.5536117553711)
 
     def _test_drpall(self, data):
+        self.assertIsInstance(data, OrderedDict)
         self.assertNotIn('profmean_ivar', data.keys())
         self.assertIn('iauname', data.keys())
         self.assertEqual(data['iauname'], 'J153010.73+484124.8')

--- a/python/marvin/tests/utils/test_general.py
+++ b/python/marvin/tests/utils/test_general.py
@@ -15,15 +15,19 @@ Revision history:
 
 from __future__ import division
 from __future__ import print_function
-from marvin.utils.general import convertCoords
+
 from unittest import TestCase
 from astropy.io import fits
 from astropy.wcs import WCS
 import os
+
 import numpy as np
 from numpy.testing import assert_allclose
-from marvin.tests import TemplateTestCase, Call, template
+
+import marvin
 from marvin.core.exceptions import MarvinError
+from marvin.tests import TemplateTestCase, Call, template
+from marvin.utils.general import convertCoords, get_nsa_data
 
 
 class TestConvertCoords(TestCase):
@@ -124,3 +128,57 @@ class TestConvertCoords(TestCase):
         with self.assertRaises(MarvinError) as cm:
             convertCoords(shape=self.testShape, **kwargs)
         self.assertIn('some indices are out of limits', str(cm.exception))
+
+
+class TestGetNSAData(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        marvin.config.switchSasUrl('local')
+        cls.config_db = marvin.config.db
+
+    def setUp(self):
+        marvin.config.db = self.config_db
+
+    def _test_nsa(self, data):
+        self.assertIn('profmean_ivar', data.keys())
+        self.assertEqual(data['profmean_ivar'][0][0], 18.5536117553711)
+
+    def _test_drpall(self, data):
+        self.assertNotIn('profmean_ivar', data.keys())
+        self.assertIn('iauname', data.keys())
+        self.assertEqual(data['iauname'], 'J153010.73+484124.8')
+
+    def test_local_nsa(self):
+        data = get_nsa_data('1-209232', source='nsa', mode='local')
+        self._test_nsa(data)
+
+    def test_local_drpall(self):
+        data = get_nsa_data('1-209232', source='drpall', mode='local')
+        self._test_drpall(data)
+
+    def test_remote_nsa(self):
+        data = get_nsa_data('1-209232', source='nsa', mode='remote')
+        self._test_nsa(data)
+
+    def test_remote_drpall(self):
+        data = get_nsa_data('1-209232', source='drpall', mode='remote')
+        self._test_drpall(data)
+
+    def test_auto_nsa_with_db(self):
+        data = get_nsa_data('1-209232', source='nsa', mode='auto')
+        self._test_nsa(data)
+
+    def test_auto_drpall_with_drpall(self):
+        data = get_nsa_data('1-209232', source='drpall', mode='auto')
+        self._test_drpall(data)
+
+    def test_auto_nsa_without_db(self):
+        marvin.config.db = None
+        data = get_nsa_data('1-209232', source='nsa', mode='auto')
+        self._test_nsa(data)
+
+    def test_auto_drpall_without_drpall(self):
+        marvin.config._drpall = None
+        data = get_nsa_data('1-209232', source='drpall', mode='auto')
+        self._test_drpall(data)

--- a/python/marvin/tools/cube.py
+++ b/python/marvin/tools/cube.py
@@ -47,6 +47,19 @@ class Cube(MarvinToolsClass):
         plateifu (str):
             The plate-ifu of the data cube to load (either ``mangaid`` or
             ``plateifu`` can be used, but not both).
+        nsa_source ({'auto', 'drpall', 'nsa'}):
+            Defines how the NSA data for this object should loaded when
+            ``Cube.nsa`` is first called. If ``drpall``, the drpall file will
+            be used (note that this will only contain a subset of all the NSA
+            information); if ``nsa``, the full set of data from the DB will be
+            retrieved. If the drpall file or a database are not available, a
+            remote API call will be attempted. If ``nsa_source='auto'``, the
+            source will depend on how the ``Cube`` object has been
+            instantiated. If the cube has ``Cube.data_origin='file'``,
+            the drpall file will be used (as it is more likely that the user
+            has that file in their system). Otherwise, ``nsa_source='nsa'``
+            will be assumed. This behaviour can be modified during runtime by
+            modifying the ``Cube.nsa_mode`` with one of the valid values.
         mode ({'local', 'remote', 'auto'}):
             The load mode to use. See :ref:`mode-decision-tree`.
         release (str):
@@ -61,7 +74,8 @@ class Cube(MarvinToolsClass):
     def __init__(self, *args, **kwargs):
 
         valid_kwargs = [
-            'data', 'filename', 'mangaid', 'plateifu', 'mode', 'release', 'drpall']
+            'data', 'filename', 'mangaid', 'plateifu', 'mode', 'release',
+            'drpall', 'nsa_source']
 
         assert len(args) == 0, 'Cube does not accept arguments, only keywords.'
         for kw in kwargs:

--- a/python/marvin/tools/maps.py
+++ b/python/marvin/tools/maps.py
@@ -144,6 +144,19 @@ class Maps(marvin.core.core.MarvinToolsClass):
             A placeholder for a future version in which stellar populations
             are fitted using a different template that ``template_kin``. It
             has no effect for now.
+        nsa_source ({'auto', 'drpall', 'nsa'}):
+            Defines how the NSA data for this object should loaded when
+            ``Cube.nsa`` is first called. If ``drpall``, the drpall file will
+            be used (note that this will only contain a subset of all the NSA
+            information); if ``nsa``, the full set of data from the DB will be
+            retrieved. If the drpall file or a database are not available, a
+            remote API call will be attempted. If ``nsa_source='auto'``, the
+            source will depend on how the ``Cube`` object has been
+            instantiated. If the cube has ``Cube.data_origin='file'``,
+            the drpall file will be used (as it is more likely that the user
+            has that file in their system). Otherwise, ``nsa_source='nsa'``
+            will be assumed. This behaviour can be modified during runtime by
+            modifying the ``Cube.nsa_mode`` with one of the valid values.
         release (str):
             The MPL/DR version of the data to use.
 
@@ -153,7 +166,7 @@ class Maps(marvin.core.core.MarvinToolsClass):
 
         valid_kwargs = [
             'data', 'filename', 'mangaid', 'plateifu', 'mode', 'release',
-            'bintype', 'template_kin', 'template_pop']
+            'bintype', 'template_kin', 'template_pop', 'nsa_source']
 
         assert len(args) == 0, 'Maps does not accept arguments, only keywords.'
         for kw in kwargs:

--- a/python/marvin/tools/maps.py
+++ b/python/marvin/tools/maps.py
@@ -146,17 +146,17 @@ class Maps(marvin.core.core.MarvinToolsClass):
             has no effect for now.
         nsa_source ({'auto', 'drpall', 'nsa'}):
             Defines how the NSA data for this object should loaded when
-            ``Cube.nsa`` is first called. If ``drpall``, the drpall file will
+            ``Maps.nsa`` is first called. If ``drpall``, the drpall file will
             be used (note that this will only contain a subset of all the NSA
             information); if ``nsa``, the full set of data from the DB will be
             retrieved. If the drpall file or a database are not available, a
             remote API call will be attempted. If ``nsa_source='auto'``, the
-            source will depend on how the ``Cube`` object has been
-            instantiated. If the cube has ``Cube.data_origin='file'``,
+            source will depend on how the ``Maps`` object has been
+            instantiated. If the cube has ``Maps.data_origin='file'``,
             the drpall file will be used (as it is more likely that the user
             has that file in their system). Otherwise, ``nsa_source='nsa'``
             will be assumed. This behaviour can be modified during runtime by
-            modifying the ``Cube.nsa_mode`` with one of the valid values.
+            modifying the ``Maps.nsa_mode`` with one of the valid values.
         release (str):
             The MPL/DR version of the data to use.
 

--- a/python/marvin/tools/modelcube.py
+++ b/python/marvin/tools/modelcube.py
@@ -68,17 +68,17 @@ class ModelCube(MarvinToolsClass):
             has no effect for now.
         nsa_source ({'auto', 'drpall', 'nsa'}):
             Defines how the NSA data for this object should loaded when
-            ``Cube.nsa`` is first called. If ``drpall``, the drpall file will
-            be used (note that this will only contain a subset of all the NSA
-            information); if ``nsa``, the full set of data from the DB will be
-            retrieved. If the drpall file or a database are not available, a
+            ``ModelCube.nsa`` is first called. If ``drpall``, the drpall file
+            will be used (note that this will only contain a subset of all the
+            NSA information); if ``nsa``, the full set of data from the DB will
+            be retrieved. If the drpall file or a database are not available, a
             remote API call will be attempted. If ``nsa_source='auto'``, the
-            source will depend on how the ``Cube`` object has been
-            instantiated. If the cube has ``Cube.data_origin='file'``,
+            source will depend on how the ``ModelCube`` object has been
+            instantiated. If the cube has ``ModelCube.data_origin='file'``,
             the drpall file will be used (as it is more likely that the user
             has that file in their system). Otherwise, ``nsa_source='nsa'``
             will be assumed. This behaviour can be modified during runtime by
-            modifying the ``Cube.nsa_mode`` with one of the valid values.
+            modifying the ``ModelCube.nsa_mode`` with one of the valid values.
         release (str):
             The MPL/DR version of the data to use.
 

--- a/python/marvin/tools/modelcube.py
+++ b/python/marvin/tools/modelcube.py
@@ -66,6 +66,19 @@ class ModelCube(MarvinToolsClass):
             A placeholder for a future version in which stellar populations
             are fitted using a different template that ``template_kin``. It
             has no effect for now.
+        nsa_source ({'auto', 'drpall', 'nsa'}):
+            Defines how the NSA data for this object should loaded when
+            ``Cube.nsa`` is first called. If ``drpall``, the drpall file will
+            be used (note that this will only contain a subset of all the NSA
+            information); if ``nsa``, the full set of data from the DB will be
+            retrieved. If the drpall file or a database are not available, a
+            remote API call will be attempted. If ``nsa_source='auto'``, the
+            source will depend on how the ``Cube`` object has been
+            instantiated. If the cube has ``Cube.data_origin='file'``,
+            the drpall file will be used (as it is more likely that the user
+            has that file in their system). Otherwise, ``nsa_source='nsa'``
+            will be assumed. This behaviour can be modified during runtime by
+            modifying the ``Cube.nsa_mode`` with one of the valid values.
         release (str):
             The MPL/DR version of the data to use.
 
@@ -79,7 +92,7 @@ class ModelCube(MarvinToolsClass):
 
         valid_kwargs = [
             'data', 'cube', 'maps', 'filename', 'mangaid', 'plateifu', 'mode',
-            'release', 'bintype', 'template_kin', 'template_pop']
+            'release', 'bintype', 'template_kin', 'template_pop', 'nsa_source']
 
         assert len(args) == 0, 'Maps does not accept arguments, only keywords.'
         for kw in kwargs:

--- a/python/marvin/tools/rss.py
+++ b/python/marvin/tools/rss.py
@@ -47,17 +47,17 @@ class RSS(MarvinToolsClass, list):
             :doc:`Mode secision tree</mode_decision>`.
         nsa_source ({'auto', 'drpall', 'nsa'}):
             Defines how the NSA data for this object should loaded when
-            ``Cube.nsa`` is first called. If ``drpall``, the drpall file will
+            ``RSS.nsa`` is first called. If ``drpall``, the drpall file will
             be used (note that this will only contain a subset of all the NSA
             information); if ``nsa``, the full set of data from the DB will be
             retrieved. If the drpall file or a database are not available, a
             remote API call will be attempted. If ``nsa_source='auto'``, the
-            source will depend on how the ``Cube`` object has been
-            instantiated. If the cube has ``Cube.data_origin='file'``,
+            source will depend on how the ``RSS`` object has been
+            instantiated. If the cube has ``RSS.data_origin='file'``,
             the drpall file will be used (as it is more likely that the user
             has that file in their system). Otherwise, ``nsa_source='nsa'``
             will be assumed. This behaviour can be modified during runtime by
-            modifying the ``Cube.nsa_mode`` with one of the valid values.
+            modifying the ``RSS.nsa_mode`` with one of the valid values.
         release (str):
             The MPL/DR version of the data to use.
 

--- a/python/marvin/tools/rss.py
+++ b/python/marvin/tools/rss.py
@@ -45,6 +45,19 @@ class RSS(MarvinToolsClass, list):
         mode ({'local', 'remote', 'auto'}):
             The load mode to use. See
             :doc:`Mode secision tree</mode_decision>`.
+        nsa_source ({'auto', 'drpall', 'nsa'}):
+            Defines how the NSA data for this object should loaded when
+            ``Cube.nsa`` is first called. If ``drpall``, the drpall file will
+            be used (note that this will only contain a subset of all the NSA
+            information); if ``nsa``, the full set of data from the DB will be
+            retrieved. If the drpall file or a database are not available, a
+            remote API call will be attempted. If ``nsa_source='auto'``, the
+            source will depend on how the ``Cube`` object has been
+            instantiated. If the cube has ``Cube.data_origin='file'``,
+            the drpall file will be used (as it is more likely that the user
+            has that file in their system). Otherwise, ``nsa_source='nsa'``
+            will be assumed. This behaviour can be modified during runtime by
+            modifying the ``Cube.nsa_mode`` with one of the valid values.
         release (str):
             The MPL/DR version of the data to use.
 
@@ -57,8 +70,8 @@ class RSS(MarvinToolsClass, list):
 
     def __init__(self, *args, **kwargs):
 
-        valid_kwargs = [
-            'filename', 'mangaid', 'plateifu', 'mode', 'drpall', 'release']
+        valid_kwargs = ['filename', 'mangaid', 'plateifu', 'mode',
+                        'drpall', 'release', 'nsa_source']
 
         assert len(args) == 0, 'RSS does not accept arguments, only keywords.'
         for kw in kwargs:

--- a/python/marvin/utils/general/general.py
+++ b/python/marvin/utils/general/general.py
@@ -907,7 +907,7 @@ def get_nsa_data(mangaid, source='nsa', mode='auto', drpver=None, drpall=None):
 
             drpall_row = get_drpall_row(plateifu, drpall=drpall, drpver=drpver)
 
-            nsa_data = {}
+            nsa_data = collections.OrderedDict()
             for col in drpall_row.colnames:
                 if col.startswith('nsa_'):
                     value = drpall_row[col]
@@ -932,6 +932,6 @@ def get_nsa_data(mangaid, source='nsa', mode='auto', drpver=None, drpall=None):
             raise MarvinError('API call to {0} failed: {1}'.format(request_name, str(ee)))
         else:
             if response.results['status'] == 1:
-                return response.getData()
+                return collections.OrderedDict(response.getData())
             else:
                 raise MarvinError('get_nsa_data: %s', response['error'])

--- a/python/marvin/utils/general/general.py
+++ b/python/marvin/utils/general/general.py
@@ -862,12 +862,14 @@ def get_nsa_data(mangaid, source='nsa', mode='auto', drpver=None, drpall=None):
     if mode == 'auto':
         log.debug('get_nsa_data: running auto mode mode.')
         try:
-            nsa_data = get_nsa_data(mangaid, mode='local', source=source)
+            nsa_data = get_nsa_data(mangaid, mode='local', source=source,
+                                    drpver=drpver, drpall=drpall)
             return nsa_data
         except MarvinError as ee:
             log.debug('get_nsa_data: local mode failed with error %s', str(ee))
             try:
-                nsa_data = get_nsa_data(mangaid, mode='remote', source=source)
+                nsa_data = get_nsa_data(mangaid, mode='remote', source=source,
+                                        drpver=drpver, drpall=drpall)
                 return nsa_data
             except MarvinError as ee:
                 raise MarvinError('get_nsa_data: failed to get NSA data for mangaid=%r in '


### PR DESCRIPTION
This PR adds a `.nsa` property to `MarvinToolsClass` (i.e., it can be accessed from `Cube`, `Maps`, `ModelCube`, and `RSS`) to access NSA information for the target. The retrieval of the NSA data itself is handled via a new function, `get_nsa_data`, in `marvin.utils.general.general`. The function allows to obtain the information from the drpall file or from `mangaSampleDB.NSA`. For each object, the default access mode is defined by a new kwarg `nsa_source`

```
nsa_source ({'auto', 'drpall', 'nsa'}):
    Defines how the NSA data for this object should loaded when
    ``Cube.nsa`` is first called. If ``drpall``, the drpall file will
    be used (note that this will only contain a subset of all the NSA
    information); if ``nsa``, the full set of data from the DB will be
    retrieved. If the drpall file or a database are not available, a
    remote API call will be attempted. If ``nsa_source='auto'``, the
    source will depend on how the ``Cube`` object has been
    instantiated. If the cube has ``Cube.data_origin='file'``,
    the drpall file will be used (as it is more likely that the user
    has that file in their system). Otherwise, ``nsa_source='nsa'``
    will be assumed. This behaviour can be modified during runtime by
    modifying the ``Cube.nsa_mode`` with one of the valid values.
```

So, by default, a tool created from file will use the drpall. `get_nsa_data` is always called with `mode='auto'`, which tries to use a local drpall or DB before using the API.

I've added a good amount of tests but, as always, additional tests are always welcome.

Fixes #108.