### PR TITLE
Fix incorrect orientation of Maps returned from DB and API

### DIFF
--- a/python/marvin/tests/tools/test_cube.py
+++ b/python/marvin/tests/tools/test_cube.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import collections
 import os
 import unittest
 
@@ -515,6 +514,66 @@ class TestGetSpaxel(TestCubeBase):
         cube = Cube(plateifu=self.plateifu, mode='remote', release='MPL-4')
         expect = 0.62007582
         self._test_getSpaxel(cube, 3000, expect, ra=232.544279, dec=48.6899232)
+
+    @skipIfNoDB
+    def test_getspaxel_matches_file_db_remote(self):
+
+        config.setMPL('MPL-4')
+        self.assertEqual(config.release, 'MPL-4')
+
+        cube_file = Cube(filename=self.filename)
+        cube_db = Cube(plateifu=self.plateifu)
+        cube_api = Cube(plateifu=self.plateifu, mode='remote')
+
+        self.assertEqual(cube_file.data_origin, 'file')
+        self.assertEqual(cube_db.data_origin, 'db')
+        self.assertEqual(cube_api.data_origin, 'api')
+
+        xx = 12
+        yy = 5
+        spec_idx = 200
+
+        spaxel_slice_file = cube_file[xx, yy]
+        spaxel_slice_db = cube_db[xx, yy]
+        spaxel_slice_api = cube_api[xx, yy]
+
+        flux_result = 0.017639931
+        ivar_result = 352.12421
+        mask_result = 1026
+
+        self.assertAlmostEqual(spaxel_slice_file.spectrum.flux[spec_idx], flux_result)
+        self.assertAlmostEqual(spaxel_slice_db.spectrum.flux[spec_idx], flux_result)
+        self.assertAlmostEqual(spaxel_slice_api.spectrum.flux[spec_idx], flux_result)
+
+        self.assertAlmostEqual(spaxel_slice_file.spectrum.ivar[spec_idx], ivar_result, places=5)
+        self.assertAlmostEqual(spaxel_slice_db.spectrum.ivar[spec_idx], ivar_result, places=3)
+        self.assertAlmostEqual(spaxel_slice_api.spectrum.ivar[spec_idx], ivar_result, places=3)
+
+        self.assertAlmostEqual(spaxel_slice_file.spectrum.mask[spec_idx], mask_result)
+        self.assertAlmostEqual(spaxel_slice_db.spectrum.mask[spec_idx], mask_result)
+        self.assertAlmostEqual(spaxel_slice_api.spectrum.mask[spec_idx], mask_result)
+
+        xx_cen = -5
+        yy_cen = -12
+
+        spaxel_getspaxel_file = cube_file.getSpaxel(x=xx_cen, y=yy_cen)
+        spaxel_getspaxel_db = cube_db.getSpaxel(x=xx_cen, y=yy_cen)
+        spaxel_getspaxel_api = cube_api.getSpaxel(x=xx_cen, y=yy_cen)
+
+        self.assertAlmostEqual(spaxel_getspaxel_file.spectrum.flux[spec_idx], flux_result)
+        self.assertAlmostEqual(spaxel_getspaxel_db.spectrum.flux[spec_idx], flux_result)
+        self.assertAlmostEqual(spaxel_getspaxel_api.spectrum.flux[spec_idx], flux_result)
+
+        self.assertAlmostEqual(spaxel_getspaxel_file.spectrum.ivar[spec_idx],
+                               ivar_result, places=5)
+        self.assertAlmostEqual(spaxel_getspaxel_db.spectrum.ivar[spec_idx],
+                               ivar_result, places=3)
+        self.assertAlmostEqual(spaxel_getspaxel_api.spectrum.ivar[spec_idx],
+                               ivar_result, places=3)
+
+        self.assertAlmostEqual(spaxel_getspaxel_file.spectrum.mask[spec_idx], mask_result)
+        self.assertAlmostEqual(spaxel_getspaxel_db.spectrum.mask[spec_idx], mask_result)
+        self.assertAlmostEqual(spaxel_getspaxel_api.spectrum.mask[spec_idx], mask_result)
 
 
 class TestWCS(TestCubeBase):

--- a/python/marvin/tests/tools/test_maps.py
+++ b/python/marvin/tests/tools/test_maps.py
@@ -368,6 +368,57 @@ class TestGetMap(TestMapsBase):
         maps_ellcoo = maps['spx_ellcoo_elliptical_radius']
         self.assertIsNone(maps_ellcoo.ivar)
 
+    def test_haflux_matches_file_db_api(self):
+
+        maps_file = marvin.tools.maps.Maps(filename=self.filename_mpl5_spx)
+        maps_db = marvin.tools.maps.Maps(plateifu=self.plateifu, release='MPL-5')
+        maps_api = marvin.tools.maps.Maps(plateifu=self.plateifu, release='MPL-5', mode='remote')
+
+        self.assertEqual(maps_file.data_origin, 'file')
+        self.assertEqual(maps_db.data_origin, 'db')
+        self.assertEqual(maps_api.data_origin, 'api')
+
+        self.assertEqual(maps_file._release, 'MPL-5')
+        self.assertEqual(maps_db._release, 'MPL-5')
+        self.assertEqual(maps_api._release, 'MPL-5')
+
+        self.assertEqual(maps_file.bintype, 'SPX')
+        self.assertEqual(maps_db.bintype, 'SPX')
+        self.assertEqual(maps_api.bintype, 'SPX')
+
+        xx = 12
+        yy = 10
+
+        flux_expected = 0.98572426396458579
+        ivar_expected = 295.06537566125365
+
+        haflux_file = maps_file['emline_gflux_ha_6564']
+        haflux_db = maps_db['emline_gflux_ha_6564']
+        haflux_api = maps_api['emline_gflux_ha_6564']
+
+        self.assertAlmostEqual(haflux_file.value[yy, xx], flux_expected)
+        self.assertAlmostEqual(haflux_db.value[yy, xx], flux_expected, places=6)
+        self.assertAlmostEqual(haflux_api.value[yy, xx], flux_expected, places=6)
+
+        self.assertAlmostEqual(haflux_file.ivar[yy, xx], ivar_expected)
+        self.assertAlmostEqual(haflux_db.ivar[yy, xx], ivar_expected, places=6)
+        self.assertAlmostEqual(haflux_api.ivar[yy, xx], ivar_expected, places=6)
+
+        haflux_spaxel_file = maps_file.getSpaxel(x=xx, y=yy,
+                                                 xyorig='lower').properties['emline_gflux_ha_6564']
+        haflux_spaxel_db = maps_db.getSpaxel(x=xx, y=yy,
+                                             xyorig='lower').properties['emline_gflux_ha_6564']
+        haflux_spaxel_api = maps_api.getSpaxel(x=xx, y=yy,
+                                               xyorig='lower').properties['emline_gflux_ha_6564']
+
+        self.assertAlmostEqual(haflux_spaxel_file.value, flux_expected)
+        self.assertAlmostEqual(haflux_spaxel_db.value, flux_expected, places=6)
+        self.assertAlmostEqual(haflux_spaxel_api.value, flux_expected, places=6)
+
+        self.assertAlmostEqual(haflux_spaxel_file.ivar, ivar_expected)
+        self.assertAlmostEqual(haflux_spaxel_db.ivar, ivar_expected, places=6)
+        self.assertAlmostEqual(haflux_spaxel_api.ivar, ivar_expected, places=6)
+
 
 class TestPickling(TestMapsBase):
 

--- a/python/marvin/tests/tools/test_modelcube.py
+++ b/python/marvin/tests/tools/test_modelcube.py
@@ -200,6 +200,65 @@ class TestGetSpaxel(TestModelCubeBase):
         self.assertIsNone(spaxel.maps)
         self.assertEqual(len(spaxel.properties), 0)
 
+    def test_getspaxel_matches_file_db_remote(self):
+
+        marvin.config.setMPL('MPL-5')
+        self.assertEqual(marvin.config.release, 'MPL-5')
+
+        modelcube_file = ModelCube(filename=self.filename)
+        modelcube_db = ModelCube(plateifu=self.plateifu)
+        modelcube_api = ModelCube(plateifu=self.plateifu, mode='remote')
+
+        self.assertEqual(modelcube_file.data_origin, 'file')
+        self.assertEqual(modelcube_db.data_origin, 'db')
+        self.assertEqual(modelcube_api.data_origin, 'api')
+
+        xx = 12
+        yy = 5
+        spec_idx = 200
+
+        spaxel_slice_file = modelcube_file[xx, yy]
+        spaxel_slice_db = modelcube_db[xx, yy]
+        spaxel_slice_api = modelcube_api[xx, yy]
+
+        flux_result = 0.016027471050620079
+        ivar_result = 361.13595581054693
+        mask_result = 33
+
+        self.assertAlmostEqual(spaxel_slice_file.model_flux.flux[spec_idx], flux_result)
+        self.assertAlmostEqual(spaxel_slice_db.model_flux.flux[spec_idx], flux_result)
+        self.assertAlmostEqual(spaxel_slice_api.model_flux.flux[spec_idx], flux_result)
+
+        self.assertAlmostEqual(spaxel_slice_file.model_flux.ivar[spec_idx], ivar_result, places=5)
+        self.assertAlmostEqual(spaxel_slice_db.model_flux.ivar[spec_idx], ivar_result, places=3)
+        self.assertAlmostEqual(spaxel_slice_api.model_flux.ivar[spec_idx], ivar_result, places=3)
+
+        self.assertAlmostEqual(spaxel_slice_file.model_flux.mask[spec_idx], mask_result)
+        self.assertAlmostEqual(spaxel_slice_db.model_flux.mask[spec_idx], mask_result)
+        self.assertAlmostEqual(spaxel_slice_api.model_flux.mask[spec_idx], mask_result)
+
+        xx_cen = -5
+        yy_cen = -12
+
+        spaxel_getspaxel_file = modelcube_file.getSpaxel(x=xx_cen, y=yy_cen)
+        spaxel_getspaxel_db = modelcube_db.getSpaxel(x=xx_cen, y=yy_cen)
+        spaxel_getspaxel_api = modelcube_api.getSpaxel(x=xx_cen, y=yy_cen)
+
+        self.assertAlmostEqual(spaxel_getspaxel_file.model_flux.flux[spec_idx], flux_result)
+        self.assertAlmostEqual(spaxel_getspaxel_db.model_flux.flux[spec_idx], flux_result)
+        self.assertAlmostEqual(spaxel_getspaxel_api.model_flux.flux[spec_idx], flux_result)
+
+        self.assertAlmostEqual(spaxel_getspaxel_file.model_flux.ivar[spec_idx],
+                               ivar_result, places=5)
+        self.assertAlmostEqual(spaxel_getspaxel_db.model_flux.ivar[spec_idx],
+                               ivar_result, places=3)
+        self.assertAlmostEqual(spaxel_getspaxel_api.model_flux.ivar[spec_idx],
+                               ivar_result, places=3)
+
+        self.assertAlmostEqual(spaxel_getspaxel_file.model_flux.mask[spec_idx], mask_result)
+        self.assertAlmostEqual(spaxel_getspaxel_db.model_flux.mask[spec_idx], mask_result)
+        self.assertAlmostEqual(spaxel_getspaxel_api.model_flux.mask[spec_idx], mask_result)
+
 
 class TestPickling(TestModelCubeBase):
 

--- a/python/marvin/tests/tools/test_modelcube.py
+++ b/python/marvin/tests/tools/test_modelcube.py
@@ -114,8 +114,8 @@ class TestModelCubeInit(TestModelCubeBase):
 
         marvin.config.setMPL('MPL-4')
         with self.assertRaises(MarvinError) as err:
-            __ = ModelCube(plateifu=self.plateifu)
-        self.assertEqual('ModelCube requires at least dapver=\'2.0.2\'',  str(err.exception))
+            ModelCube(plateifu=self.plateifu)
+        self.assertEqual('ModelCube requires at least dapver=\'2.0.2\'', str(err.exception))
 
     def test_init_from_db_not_default(self):
 
@@ -138,8 +138,8 @@ class TestModelCubeInit(TestModelCubeBase):
 
         model_cube = ModelCube(plateifu=self.plateifu, mode='remote')
         with self.assertRaises(MarvinError) as err:
-            __ = model_cube.flux
-        self.assertIn('cannot return a full cube in remote mode.',  str(err.exception))
+            model_cube.flux
+        self.assertIn('cannot return a full cube in remote mode.', str(err.exception))
 
     def test_get_cube_file(self):
 

--- a/python/marvin/tools/map.py
+++ b/python/marvin/tools/map.py
@@ -146,19 +146,19 @@ class Map(object):
         fullname_value = self.maps_property.fullname(channel=self.channel)
         value = mdb.session.query(getattr(table, fullname_value)).filter(
             table.file_pk == self.maps.data.pk).order_by(table.spaxel_index).all()
-        self.value = numpy.array(value).reshape(self.shape)
+        self.value = numpy.array(value).reshape(self.shape).T
 
         if self.maps_property.ivar:
             fullname_ivar = self.maps_property.fullname(channel=self.channel, ext='ivar')
             ivar = mdb.session.query(getattr(table, fullname_ivar)).filter(
                 table.file_pk == self.maps.data.pk).order_by(table.spaxel_index).all()
-            self.ivar = numpy.array(ivar).reshape(self.shape)
+            self.ivar = numpy.array(ivar).reshape(self.shape).T
 
         if self.maps_property.mask:
             fullname_mask = self.maps_property.fullname(channel=self.channel, ext='mask')
             mask = mdb.session.query(getattr(table, fullname_mask)).filter(
                 table.file_pk == self.maps.data.pk).order_by(table.spaxel_index).all()
-            self.mask = numpy.array(mask).reshape(self.shape)
+            self.mask = numpy.array(mask).reshape(self.shape).T
 
         # Gets the header
         hdus = self.maps.data.hdus


### PR DESCRIPTION
This should fix #148, at least temporarily. The individual maps returned by the DB (and, thus, also by the API) are transposed. A simple `.T` in the returned array solves the problem. I have added test to `test_cube` and `test_maps` to check that the returned values (flux, ivar, mask) from file, db, and API agree and match what one expects from the file when opening it with astropy. This problems seems to affect only to maps, the spectra from cubes are correctly returned in all cases.

Moving forward, we can either keep this fix or, probably better, flip the x and y columns in spaxelprop and spaxelprop5 (I think that should have the same effect as transposing the array).