### PR TITLE
Added release property

### DIFF
--- a/python/marvin/core/core.py
+++ b/python/marvin/core/core.py
@@ -274,6 +274,18 @@ class MarvinToolsClass(object):
 
         return self._nsa
 
+    @property
+    def release(self):
+        """Returns the release."""
+
+        return self._release
+
+    @release.setter
+    def release(self, value):
+        """Fails when trying to set the release after instatiation."""
+
+        raise MarvinError('the release cannot be changed once the object has been instantiated.')
+
 
 class Dotable(dict):
     """A custom dict class that allows dot access to nested dictionaries.

--- a/python/marvin/tests/tools/test_cube.py
+++ b/python/marvin/tests/tools/test_cube.py
@@ -232,6 +232,16 @@ class TestCube(TestCubeBase):
         self.assertEqual(cube.nsa_source, 'drpall')
         self._test_nsa(cube.nsa)
 
+    def test_release(self):
+        cube = Cube(plateifu=self.plateifu)
+        self.assertEqual(cube.release, 'MPL-4')
+
+    def test_set_release_fails(self):
+        cube = Cube(plateifu=self.plateifu)
+        with self.assertRaises(MarvinError) as ee:
+            cube.release = 'a'
+            self.assertIn('the release cannot be changed', str(ee.exception))
+
 
 class TestGetSpaxel(TestCubeBase):
 

--- a/python/marvin/tests/tools/test_spaxel.py
+++ b/python/marvin/tests/tools/test_spaxel.py
@@ -230,6 +230,17 @@ class TestSpaxelInit(TestSpaxelBase):
         self.assertAlmostEqual(spaxel.ra, 232.54512, places=5)
         self.assertAlmostEqual(spaxel.dec, 48.690062, places=5)
 
+    def test_release(self):
+
+        cube = marvin.tools.cube.Cube(plateifu=self.plateifu)
+        spaxel = Spaxel(x=15, y=16, cube=cube)
+
+        self.assertEqual(spaxel.release, 'MPL-4')
+
+        with self.assertRaises(MarvinError) as ee:
+            spaxel.release = 'a'
+            self.assertIn('the release cannot be changed', str(ee.exception))
+
 
 class TestPickling(TestSpaxelBase):
 

--- a/python/marvin/tools/bin.py
+++ b/python/marvin/tools/bin.py
@@ -77,6 +77,8 @@ class Bin(object):
         self._load_spaxels(**kwargs)
         self._load_data(**kwargs)
 
+        self.release = self._maps.release
+
     def __repr__(self):
         return ('<Marvin Bin (binid={0}, n_spaxels={1}, bintype={2}, template_kin={3})>'
                 .format(self.binid, len(self.spaxels), self._maps.bintype,

--- a/python/marvin/tools/map.py
+++ b/python/marvin/tools/map.py
@@ -75,6 +75,8 @@ class Map(object):
         self.channel = channel.lower() if channel else None
         self.shape = self.maps.shape
 
+        self.release = maps.release
+
         self.maps_property = self.maps.properties[self.property_name]
         if (self.maps_property is None or
                 (self.maps_property.channels is not None and

--- a/python/marvin/tools/spaxel.py
+++ b/python/marvin/tools/spaxel.py
@@ -762,3 +762,15 @@ class Spaxel(object):
             wavelength=self.modelcube.wavelength,
             wavelength_unit='Angstrom',
             mask=model_emline_mask)
+
+    @property
+    def release(self):
+        """Returns the release."""
+
+        return self._release
+
+    @release.setter
+    def release(self, value):
+        """Fails when trying to set the release after instatiation."""
+
+        raise MarvinError('the release cannot be changed once the object has been instantiated.')


### PR DESCRIPTION
This fixes both #152 and #138. It simply adds a new property to `MarvinToolClass` that returns `_release` but fails if you try to set the property.