### PR TITLE
updated query mode to better reflect config.mode and not change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Issue #145: Limited the number of query parameters in the web
 - Added more tests to Results for sorting, paging, and getting subsets
 - Added kwargs input for Spaxel when using Result.convertToTool
+- Added Results option to save to CSV
 
 ### Changed:
 - When marvin is running from source (not dist), `marvin.__version__` is `dev`.
@@ -29,6 +30,8 @@
 - Syntax changes and bug fixes to get Marvin Web working when Marvin run on 3.5
 - Got Queries and Results working in 3.5
 - Changed all convertToTool options in Results from mangaid to plateifu
+- Modified the decision tree in query to throw an error in local mode
+- Modified convertToTool to accept a mode keyword
 
 ### Fixed:
 - Issue #115: drpall does not get updated when a tool sets a custom release.

--- a/python/marvin/__init__.py
+++ b/python/marvin/__init__.py
@@ -366,6 +366,12 @@ class MarvinConfig(object):
         from marvin import marvindb
         marvindb.forceDbOff()
 
+    def forceDbOn(self):
+        ''' Force the database to be reconnected '''
+        self._setDbConfig()
+        from marvin import marvindb
+        marvindb.forceDbOn(dbtype=self.db)
+
     def _addExternal(self, name):
         ''' Adds an external product into the path '''
         assert type(name) == str, 'name must be a string'

--- a/python/marvin/db/marvindb.py
+++ b/python/marvin/db/marvindb.py
@@ -27,6 +27,10 @@ class MarvinDB(object):
         self.db = None
         self.log = kwargs.get('log', None)
         self.error = []
+        self.__init_the_db()
+
+    def __init_the_db(self):
+        ''' Initialize the db '''
         if self.dbtype:
             self._setupDB()
         if self.db:
@@ -122,6 +126,10 @@ class MarvinDB(object):
         self.datadb = None
         self.dapdb = None
         self.sampledb = None
+
+    def forceDbOn(self, dbtype=None):
+        ''' Force the database to turn on '''
+        self.__init_the_db()
 
     def generateClassDict(self, module=None, lower=None):
         ''' Generates a dictionary of the Model Classes, based on class name as key, to the object class.

--- a/python/marvin/db/models/DataModelClasses.py
+++ b/python/marvin/db/models/DataModelClasses.py
@@ -17,7 +17,7 @@ from sqlalchemy.dialects.postgresql import *
 from sqlalchemy.types import Float, Integer
 from sqlalchemy.orm.session import Session
 from sqlalchemy import select, func  # for aggregate, other functions
-from sqlalchemy.ext.hybrid import hybrid_property, hybrid_method, Comparator
+from sqlalchemy.ext.hybrid import hybrid_property, hybrid_method
 from sqlalchemy.sql import column
 from marvin.db.ArrayUtils import ARRAY_D
 from marvin.core.caching_query import RelationshipCache
@@ -175,21 +175,6 @@ class ArrayOps(object):
             return None
 
         return indices
-
-
-class ConcatComparator(Comparator):
-    ''' '''
-    def __init__(self, A, B):
-        self.concatparam = func.concat(A, '-', B)
-
-    def __clause_element__(self):
-        return self.concatparam
-
-    def __eq__(self):
-        return self.__clause_element__() == self.concatparam
-
-    def __str__(self):
-        return self.concatparam
 
 
 class Cube(Base, ArrayOps):
@@ -359,10 +344,6 @@ class Cube(Base, ArrayOps):
     def plateifu(self):
         '''Returns parameter plate-ifu'''
         return '{0}-{1}'.format(self.plate, self.ifu.name)
-
-    # @plateifu.comparator
-    # def plateifu(cls):
-    #     return ConcatComparator(Cube.plate, IFUDesign.name)
 
     @plateifu.expression
     def plateifu(cls):

--- a/python/marvin/tests/tools/test_results.py
+++ b/python/marvin/tests/tools/test_results.py
@@ -41,6 +41,7 @@ class TestResultsBase(MarvinTest):
         config.mode = self.init_mode
         config.urlmap = self.init_urlmap
         config.setMPL('MPL-5')
+        config.forceDbOn()
 
         self.filter = 'nsa.z < 0.1 and cube.plate==8485'
         self.columns = ['cube.mangaid', 'cube.plate', 'cube.plateifu', 'ifu.name', 'nsa.z']
@@ -247,6 +248,23 @@ class TestResultsConvertTool(TestResultsBase):
     def test_convert_to_tool_remote(self):
         self._setRemote()
         self._convertTool()
+
+    def test_convert_tool_auto(self):
+        self._setRemote()
+        r = self._run_query()
+        r.convertToTool('cube', mode='auto')
+        self.assertEqual('remote', r.mode)
+        self.assertEqual('local', r.objects[0].mode)
+        self.assertEqual('db', r.objects[0].data_origin)
+
+    def test_convert_tool_auto_nodb(self):
+        self._setRemote()
+        config.forceDbOff()
+        r = self._run_query()
+        r.convertToTool('cube', mode='auto', limit=1)
+        self.assertEqual('remote', r.mode)
+        self.assertEqual('local', r.objects[0].mode)
+        self.assertEqual('file', r.objects[0].data_origin)
 
 
 class TestResultsPickling(TestResultsBase):

--- a/python/marvin/tools/query/__init__.py
+++ b/python/marvin/tools/query/__init__.py
@@ -1,2 +1,4 @@
-from marvin.tools.query.query import *
-from marvin.tools.query.results import *
+from marvin.tools.query.query import Query, doQuery
+from marvin.tools.query.results import Results
+
+

--- a/python/marvin/tools/query/query.py
+++ b/python/marvin/tools/query/query.py
@@ -191,8 +191,10 @@ class Query(object):
         if self.mode == 'remote':
             self._doRemote()
         if self.mode == 'auto':
-            self._doLocal()
-            if self.mode == 'remote':
+            try:
+                self._doLocal()
+            except Exception as e:
+                warnings.warn('local mode failed. Trying remote now.', MarvinUserWarning)
                 self._doRemote()
 
         # get return type
@@ -243,8 +245,8 @@ class Query(object):
         ''' Tests if it is possible to perform queries locally. '''
 
         if not config.db or not self.session:
-            warnings.warn('No local database found. Setting mode to remote', MarvinUserWarning)
-            self.mode = 'remote'
+            warnings.warn('No local database found. Cannot perform queries.', MarvinUserWarning)
+            raise MarvinError('No local database found.  Query cannot be run in local mode')
         else:
             self.mode = 'local'
 
@@ -252,7 +254,7 @@ class Query(object):
         ''' Sets up to perform queries remotely. '''
 
         if not config.urlmap:
-            raise MarvinError('No URL Map found.  Cannot make remote calls!')
+            raise MarvinError('No URL Map found.  Cannot make remote query calls!')
         else:
             self.mode = 'remote'
 

--- a/python/marvin/tools/query/query.py
+++ b/python/marvin/tools/query/query.py
@@ -30,6 +30,7 @@ import warnings
 import os
 from marvin.core import marvin_pickle
 from functools import wraps
+from marvin.tools.query.results import remote_mode_only
 
 try:
     import cPickle as pickle
@@ -436,6 +437,7 @@ class Query(object):
                 bestkeys = ii.getData()
                 return bestkeys
 
+    @remote_mode_only
     def save(self, path=None, overwrite=False):
         ''' Save the query as a pickle object
 
@@ -477,7 +479,7 @@ class Query(object):
             os.makedirs(dirname)
 
         try:
-            pickle.dump(self, open(path, 'w'), protocol=-1)
+            pickle.dump(self, open(path, 'wb'), protocol=-1)
         except Exception as ee:
             if os.path.exists(path):
                 os.remove(path)

--- a/python/marvin/tools/query/results.py
+++ b/python/marvin/tools/query/results.py
@@ -30,27 +30,27 @@ except ImportError:
 __all__ = ['Results']
 
 
-def local_mode_only(func):
+def local_mode_only(fxn):
     '''Decorator that bypasses function if in remote mode.'''
 
-    @wraps(func)
+    @wraps(fxn)
     def wrapper(self, *args, **kwargs):
         if self.mode == 'remote':
-            raise MarvinError('{0} not available in remote mode'.format(func.__name__))
+            raise MarvinError('{0} not available in remote mode'.format(fxn.__name__))
         else:
-            return func(self, *args, **kwargs)
+            return fxn(self, *args, **kwargs)
     return wrapper
 
 
-def remote_mode_only(func):
+def remote_mode_only(fxn):
     '''Decorator that bypasses function if in local mode.'''
 
-    @wraps(func)
+    @wraps(fxn)
     def wrapper(self, *args, **kwargs):
         if self.mode == 'local':
-            raise MarvinError('{0} not available in local mode'.format(func.__name__))
+            raise MarvinError('{0} not available in local mode'.format(fxn.__name__))
         else:
-            return func(self, *args, **kwargs)
+            return fxn(self, *args, **kwargs)
     return wrapper
 
 
@@ -402,6 +402,12 @@ class Results(object):
 
         # set Marvin query object to None, in theory this could be pickled as well
         self._queryobj = None
+        try:
+            isnotstr = type(self.query) != unicode
+        except NameError as e:
+            isnotstr = type(self.query) != str
+        if isnotstr:
+            self.query = None
 
         sf = self.searchfilter.replace(' ', '') if self.searchfilter else 'anon'
         # set the path
@@ -426,7 +432,7 @@ class Results(object):
             os.makedirs(dirname)
 
         try:
-            pickle.dump(self, open(path, 'w'), protocol=-1)
+            pickle.dump(self, open(path, 'wb'), protocol=-1)
         except Exception as ee:
             if os.path.exists(path):
                 os.remove(path)

--- a/python/marvin/tools/query/results.py
+++ b/python/marvin/tools/query/results.py
@@ -916,6 +916,9 @@ class Results(object):
                 limit (int):
                     Limit the number of results you convert to Marvin tools.  Useful
                     for extremely large result sets.  Default is None.
+                mode (str):
+                    The mode to use when attempting to convert to Tool. Default mode
+                    is to use the mode internal to Results. (most often remote mode)
 
             Example:
                 >>> # Get the results from some query
@@ -939,6 +942,7 @@ class Results(object):
         '''
 
         # set the desired tool type
+        mode = kwargs.get('mode', self.mode)
         limit = kwargs.get('limit', None)
         toollist = ['cube', 'spaxel', 'maps', 'rss', 'modelcube']
         tooltype = tooltype if tooltype else self.returntype
@@ -951,7 +955,7 @@ class Results(object):
         if tooltype == 'cube':
             self.objects = [Cube(plateifu=res.__getattribute__(
                             self._getRefName('cube.plateifu')),
-                            mode=self.mode) for res in self.results[0:limit]]
+                            mode=mode) for res in self.results[0:limit]]
         elif tooltype == 'maps':
 
             isbin = 'bintype.name' in paramlist
@@ -959,7 +963,7 @@ class Results(object):
             self.objects = []
 
             for res in self.results[0:limit]:
-                mapkwargs = {'mode': self.mode, 'plateifu': res.__getattribute__(self._getRefName('cube.plateifu'))}
+                mapkwargs = {'mode': mode, 'plateifu': res.__getattribute__(self._getRefName('cube.plateifu'))}
 
                 if isbin:
                     binval = res.__getattribute__(self._getRefName('bintype.name'))
@@ -990,7 +994,7 @@ class Results(object):
         elif tooltype == 'rss':
             self.objects = [RSS(plateifu=res.__getattribute__(
                             self._getRefName('cube.plateifu')),
-                            mode=self.mode) for res in self.results[0:limit]]
+                            mode=mode) for res in self.results[0:limit]]
         elif tooltype == 'modelcube':
 
             isbin = 'bintype.name' in paramlist
@@ -998,7 +1002,7 @@ class Results(object):
             self.objects = []
 
             for res in self.results[0:limit]:
-                mapkwargs = {'mode': self.mode, 'plateifu': res.__getattribute__(self._getRefName('cube.plateifu'))}
+                mapkwargs = {'mode': mode, 'plateifu': res.__getattribute__(self._getRefName('cube.plateifu'))}
 
                 if isbin:
                     binval = res.__getattribute__(self._getRefName('bintype.name'))

--- a/python/marvin/tools/query/results.py
+++ b/python/marvin/tools/query/results.py
@@ -317,6 +317,24 @@ class Results(object):
         table.write(filename, format='fits')
         print('Writing new FITS file {0}'.format(filename))
 
+    def toCSV(self, filename='myresults.csv'):
+        ''' Output the results as a CSV file
+
+        Writes a new CSV file from search results using
+        the astropy Table.write()
+
+        Parameters:
+            filename (str):
+                Name of CSV file to output
+
+        '''
+        myext = os.path.splitext(filename)[1]
+        if not myext:
+            filename = filename+'.csv'
+        table = self.toTable()
+        table.write(filename, format='csv')
+        print('Writing new CSV file {0}'.format(filename))
+
     def toDF(self):
         '''Call toDataFrame().
         '''


### PR DESCRIPTION
This resolves #162 #161.   I have updated the Query mode to raise an error if the mode is local if there is no database.  If the mode is remote and there is no urlmap it will also raise an error.  Query no longer switches the mode automatically to remote.  The query still explicitly passes its mode into Results.  The Results has no decision tree of its own.  

I've added a mode keyword option into the convertToTool method.  This allows the user to explicitly set how they want to convert the tools independent of the query or results.  Doing `r.convertToTool("cube", mode="auto")` will use `auto` during conversion and produce a mix of files and api data_origins if you have them.  If not set, this keyword defaults to the internal mode set inside Results. 

I've added a toCSV method into the Results object.  I've also added new pickling tests that pass in py2.7 and py3.5.  You can now no longer pickle a query when in local mode. 