### PR TITLE
NSA fix for 7443

### DIFF
--- a/python/marvin/api/cube.py
+++ b/python/marvin/api/cube.py
@@ -13,6 +13,7 @@ from marvin.utils.general import parseIdentifier
 from marvin.tools.cube import Cube
 
 from brain.utils.general import parseRoutePath
+from brain.core.exceptions import BrainError
 
 ''' stuff that runs server-side '''
 
@@ -164,13 +165,20 @@ class CubeView(BaseView):
 
         cube, res = _getCube(name)
         self.update_results(res)
+
         if cube:
+
+            try:
+                nsa_data = cube.nsa
+            except (MarvinError, BrainError):
+                nsa_data = None
+
             wavelength = (cube.wavelength.tolist() if isinstance(cube.wavelength, np.ndarray)
                           else cube.wavelength)
             self.results['data'] = {name: '{0}, {1}, {2}, {3}'.format(name, cube.plate,
                                                                       cube.ra, cube.dec),
                                     'header': cube.header.tostring(),
-                                    'redshift': cube.redshift,
+                                    'redshift': nsa_data.z if nsa_data else -1,
                                     'shape': cube.shape,
                                     'wavelength': wavelength,
                                     'wcs_header': cube.wcs.to_header_string()}

--- a/python/marvin/api/cube.py
+++ b/python/marvin/api/cube.py
@@ -178,7 +178,7 @@ class CubeView(BaseView):
             self.results['data'] = {name: '{0}, {1}, {2}, {3}'.format(name, cube.plate,
                                                                       cube.ra, cube.dec),
                                     'header': cube.header.tostring(),
-                                    'redshift': nsa_data.z if nsa_data else -1,
+                                    'redshift': nsa_data.z if nsa_data else -9999,
                                     'shape': cube.shape,
                                     'wavelength': wavelength,
                                     'wcs_header': cube.wcs.to_header_string()}

--- a/python/marvin/core/core.py
+++ b/python/marvin/core/core.py
@@ -20,6 +20,8 @@ import warnings
 
 import astropy.io.fits
 
+from brain.core.exceptions import BrainError
+
 import marvin
 import marvin.api.api
 from marvin.core import marvin_pickle
@@ -275,10 +277,14 @@ class MarvinToolsClass(object):
             else:
                 nsa_source = self.nsa_source
 
-            self._nsa = get_nsa_data(self.mangaid, mode='auto',
-                                     source=nsa_source,
-                                     drpver=self._drpver,
-                                     drpall=self._drpall)
+            try:
+                self._nsa = get_nsa_data(self.mangaid, mode='auto',
+                                         source=nsa_source,
+                                         drpver=self._drpver,
+                                         drpall=self._drpall)
+            except (MarvinError, BrainError):
+                warnings.warn('cannot load NSA information for mangaid={0}.'.format(self.mangaid))
+                return None
 
         return self._nsa
 

--- a/python/marvin/tests/tools/test_cube.py
+++ b/python/marvin/tests/tools/test_cube.py
@@ -169,15 +169,15 @@ class TestCube(TestCubeBase):
 
     def test_cube_file_redshift(self):
         cube = Cube(filename=self.filename)
-        self.assertAlmostEqual(cube.redshift, 0.0407447)
+        self.assertAlmostEqual(cube.nsa.redshift, 0.0407447)
 
     def test_cube_db_redshift(self):
         cube = Cube(plateifu=self.plateifu, mode='local')
-        self.assertAlmostEqual(cube.redshift, 0.0407447)
+        self.assertAlmostEqual(cube.nsa.z, 0.0407447)
 
     def test_cube_remote_redshift(self):
         cube = Cube(plateifu=self.plateifu, mode='remote')
-        self.assertAlmostEqual(cube.redshift, 0.0407447)
+        self.assertAlmostEqual(cube.nsa.z, 0.0407447)
 
     def _test_nsa(self, nsa_data, mode='nsa'):
         self.assertIsInstance(nsa_data, DotableCaseInsensitive)
@@ -241,6 +241,33 @@ class TestCube(TestCubeBase):
         with self.assertRaises(MarvinError) as ee:
             cube.release = 'a'
             self.assertIn('the release cannot be changed', str(ee.exception))
+
+    def test_load_7443_12701_file(self):
+        """Loads a cube that is not in the NSA catalogue."""
+
+        config.setMPL('MPL-5')
+        filename = os.path.realpath(os.path.join(
+            os.getenv('MANGA_SPECTRO_REDUX'), 'v2_0_1',
+            '7443/stack/manga-7443-12701-LOGCUBE.fits.gz'))
+        cube = Cube(filename=filename)
+        self.assertEqual(cube.data_origin, 'file')
+        self.assertIn('elpetro_amivar', cube.nsa)
+
+    def test_load_7443_12701_db(self):
+        """Loads a cube that is not in the NSA catalogue."""
+
+        config.setMPL('MPL-5')
+        cube = Cube(plateifu='7443-12701')
+        self.assertEqual(cube.data_origin, 'db')
+        self.assertIsNone(cube.nsa)
+
+    def test_load_7443_12701_api(self):
+        """Loads a cube that is not in the NSA catalogue."""
+
+        config.setMPL('MPL-5')
+        cube = Cube(plateifu='7443-12701', mode='remote')
+        self.assertEqual(cube.data_origin, 'api')
+        self.assertIsNone(cube.nsa)
 
 
 class TestGetSpaxel(TestCubeBase):


### PR DESCRIPTION
This PR removes the automatic loading of redshift in `Cube` to avoid problems with galaxies not in the NSA (e.g., 7443-12701 reported in #129).

The key is that we want this change to not break backwards compatibility with the API for previous versions of Marvin. The API side of `getCube` now check whether it can grab the NSA information and, if it cannot, it returns `redshift=-1`. If the NSA is available it returns `cube.nsa.z` (this will not be used by marvin>=2.1, but it will for previous versions).

In `Cube` I have removed all loading of redshift. The redshift should now be accessed via `cube.nsa.[z/redshift]`.

I have added a few tests for 7443-12701 and tried to test it in an order such that I think it will work when Utah is running 2.1 and an user is running 2.0.9. But we should check that again before releasing.

On a related note, at some point we (i.e., probably me) decided that if we load a cube from a file the NSA data would be grabbed form the DRPall, while if it was form DB or API it would be gotten from the NSA table in the DB (or via a call to the remote which would use the DB). This was, in principle, for consistency, so that if you are working locally you'd get all local results. An issue now is that if you load 7443-12701 from file you do get a `cube.nsa` attribute with data (from the DRPall) but if you load it from the DB or API `cube.nsa=None`. We may want to rethink this at some point.

Fixes #129