### PR TITLE
snr to snr_min for BPT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 ### Changed:
 - Per Issue #186: Switched to using the elpetro version of stellar mass, absolute magnitude i-band, and i-band
   mass-to-light ratio for NSA web display, from sersic values. (elpetro_logmass, elpetro_absmag_i, elpetro_mtol_i)
+- Issue #188: deprecated snr in favour of snr_min for get_bpt. snr can still be used.
 
 ### Fixed:
+- A bug in the calculation of the composite mask for BPT.
+-
 
 ## [2.1.1] - 2017/02/18
 ### Added:
@@ -20,6 +23,7 @@
 
 ### Fixed:
 - Issue #181: web display of maps were inverted; changed to xyz[jj, ii, val] in heatmap.js
+
 
 ## [2.1.0] - 2017/02/16
 ### Added:

--- a/docs/sphinx/known-issues.rst
+++ b/docs/sphinx/known-issues.rst
@@ -61,10 +61,14 @@ Tools
 
 * **Queries** - Marvin Queries work!, but they are sometimes intermittent.  You sometimes may receive this error ``MarvinError: API Query call failed: Requests Http Status Error: 404 Client Error: Not Found for url: https://api.sdss.org/test/marvin2/api/query/cubes/.``  If you do, then just wait a moment, and try your query again.  Sometimes the query succeeds on the server-side and caches your results, but fails when sending it back to you.  We don't yet know why this happens, but we are currently trying to understand this problem!
 
+* **BPT diagrams** - After the release of Marvin 2.1, a bug was found in the calculation of the
+  composite mask in the BPT diagrams. This will be fixed in Marvin 2.1.2 but until that time please
+  do not use the composite mask.
+
 Web
 :::
 
-* **Autocomplete Galaxy ID list** - Upon intitial page load, this may initially crash and fail to load a list.  A list of possible ids should appear after navigating to a new page.
+* **Autocomplete Galaxy ID list** - Upon initial page load, this may initially crash and fail to load a list.  A list of possible ids should appear after navigating to a new page.
 
 
 Still having problems?

--- a/docs/sphinx/tools/bpt.rst
+++ b/docs/sphinx/tools/bpt.rst
@@ -76,11 +76,11 @@ When using a dictionary to define your minimum SNR, it takes the form of ``{emis
     maps = Maps(plateifu='8485-1901')
 
     # generate a bpt plot using a sinlge minimum SNR of 5
-    masks, fig = maps.get_bpt(snr=5)
+    masks, fig = maps.get_bpt(snr_min=5)
 
     # generate a bpt plot using a minimum Halpha SNR of 5 and a minimum SII SNR of 2.  The remaining lines have minimum SNRs of 3.
     snrdict = {'ha': 5, 'sii': 2}
-    masks, fig = maps.get_bpt(snr=snrdict)
+    masks, fig = maps.get_bpt(snr_min=snrdict)
 
 Using the Masks
 ---------------

--- a/python/marvin/core/exceptions.py
+++ b/python/marvin/core/exceptions.py
@@ -20,7 +20,7 @@ import sys
 import marvin
 
 __all__ = ['MarvinError', 'MarvinUserWarning', 'MarvinSkippedTestWarning',
-           'MarvinNotImplemented', 'MarvinMissingDependency']
+           'MarvinNotImplemented', 'MarvinMissingDependency', 'MarvinDeprecationWarning']
 
 
 class MarvinSentry(object):
@@ -106,6 +106,11 @@ class MarvinSkippedTestWarning(MarvinUserWarning):
     pass
 
 
+class MarvinDeprecationWarning(MarvinUserWarning):
+    """A warning for deprecated features."""
+    pass
+
+
 class MarvinBreadCrumb(object):
     """ A Sentry Breadcrumb to help leave a trail to bugs """
 
@@ -156,4 +161,3 @@ class MarvinBreadCrumb(object):
         '''
 
         self.breadcrumbs.record(**kwargs)
-

--- a/python/marvin/tools/maps.py
+++ b/python/marvin/tools/maps.py
@@ -639,7 +639,8 @@ class Maps(marvin.core.core.MarvinToolsClass):
 
         return spaxels
 
-    def get_bpt(self, method='kewley06', snr=3, return_figure=True, show_plot=True, use_oi=True):
+    def get_bpt(self, method='kewley06', snr_min=3, return_figure=True,
+                show_plot=True, use_oi=True, **kwargs):
         """Returns the BPT diagram for this target.
 
         This method calculates the BPT diagram for this target using emission line maps and
@@ -654,12 +655,12 @@ class Maps(marvin.core.core.MarvinToolsClass):
                 Kewley et al. (2006). Other methods may be added in the future. For a detailed
                 explanation of the implementation of the method check the
                 :ref:`BPT documentation <marvin-bpt>`.
-            snr (float or dict):
+            snr_min (float or dict):
                 The signal-to-noise cutoff value for the emission lines used to generate the BPT
-                diagram. If ``snr`` is a single value, that signal-to-noise will be used for all
-                the lines. Alternatively, a dictionary of signal-to-noise values, with the
+                diagram. If ``snr_min`` is a single value, that signal-to-noise will be used for
+                all the lines. Alternatively, a dictionary of signal-to-noise values, with the
                 emission line channels as keys, can be used.
-                E.g., ``snr={'ha': 5, 'nii': 3, 'oi': 1}``. If some values are not provided,
+                E.g., ``snr_min={'ha': 5, 'nii': 3, 'oi': 1}``. If some values are not provided,
                 they will default to ``SNR>=3``.
             return_figure (bool):
                 If ``True``, it also returns the matplotlib figure_ of the BPT diagram plot,
@@ -699,9 +700,18 @@ class Maps(marvin.core.core.MarvinToolsClass):
 
         """
 
+        if 'snr' in kwargs:
+            warnings.warn('snr is deprecated. Use snr_min instead. '
+                          'snr will be removed in a future version of marvin',
+                          marvin.core.exceptions.MarvinDeprecationWarning)
+            snr_min = kwargs.pop('snr')
+        elif len(kwargs.keys()) > 0:
+            raise marvin.core.exceptions.MarvinError(
+                'unknown keyword {0}'.format(list(kwargs.keys())[0]))
+
         # Makes sure all the keys in the snr keyword are lowercase
-        if isinstance(snr, dict):
-            snr = dict((kk.lower(), vv) for kk, vv in snr.items())
+        if isinstance(snr_min, dict):
+            snr_min = dict((kk.lower(), vv) for kk, vv in snr_min.items())
 
         # If we don't want the figure but want to show the plot, we still need to
         # temporarily get it.
@@ -712,7 +722,7 @@ class Maps(marvin.core.core.MarvinToolsClass):
         if not show_plot and plt_was_interactive:
             plt.ioff()
 
-        bpt_return = marvin.utils.dap.bpt.bpt_kewley06(self, snr=snr,
+        bpt_return = marvin.utils.dap.bpt.bpt_kewley06(self, snr_min=snr_min,
                                                        return_figure=do_return_figure,
                                                        use_oi=use_oi)
 


### PR DESCRIPTION
This should fix #188. `snr` is now deprecated in favour of `snr_min`. If `snr` is used, a `MarvinDeprecationWarning` is issued and the value of `snr` is used for `snr_min`. At some point we may want to remove `snr` completely.

I have updated the tests and the documentation.