### PR TITLE
Make cube.flux work in remote mode

### DIFF
--- a/python/marvin/__init__.py
+++ b/python/marvin/__init__.py
@@ -466,5 +466,5 @@ marvindb = MarvinDB(dbtype=config.db)
 # Inits the URL Route Map
 from marvin.api.api import Interaction
 config.sasurl = 'https://api.sdss.org/marvin2/'
-# config.sasurl = 'http://24147588.ngrok.io/marvin2/'  # this is a temporary measure REMOVE THIS
-# config.sasurl = 'http://localhost:5000/marvin2/'
+config.switchSasUrl('local')
+

--- a/python/marvin/__init__.py
+++ b/python/marvin/__init__.py
@@ -466,5 +466,4 @@ marvindb = MarvinDB(dbtype=config.db)
 # Inits the URL Route Map
 from marvin.api.api import Interaction
 config.sasurl = 'https://api.sdss.org/marvin2/'
-config.switchSasUrl('local')
 

--- a/python/marvin/api/__init__.py
+++ b/python/marvin/api/__init__.py
@@ -32,8 +32,8 @@ viewargs = {'name': fields.String(required=True, location='view_args', validate=
             'x': fields.Integer(required=True, location='view_args', validate=validate.Range(min=0, max=100)),
             'y': fields.Integer(required=True, location='view_args', validate=validate.Range(min=0, max=100)),
             'mangaid': fields.String(required=True, location='view_args', validate=validate.Length(min=4, max=20)),
-            'paramdisplay': fields.String(required=True, validate=validate.OneOf(['all', 'best'])),
-            'cube_extension': fields.String(required=True,
+            'paramdisplay': fields.String(required=True, location='view_args', validate=validate.OneOf(['all', 'best'])),
+            'cube_extension': fields.String(required=True, location='view_args',
                                             validate=validate.OneOf(['flux', 'ivar', 'mask']))
             }
 
@@ -112,7 +112,6 @@ class ArgValidator(object):
         ''' Retrieve the URL route from the map based on the request endpoint '''
         blue, end = self.endpoint.split('.', 1)
         url = self.urlmap[blue][end]['url']
-
         # if the blueprint is not api, add/remove session option location
         if blue == 'api':
             if 'session' in parser.locations:

--- a/python/marvin/api/__init__.py
+++ b/python/marvin/api/__init__.py
@@ -32,7 +32,9 @@ viewargs = {'name': fields.String(required=True, location='view_args', validate=
             'x': fields.Integer(required=True, location='view_args', validate=validate.Range(min=0, max=100)),
             'y': fields.Integer(required=True, location='view_args', validate=validate.Range(min=0, max=100)),
             'mangaid': fields.String(required=True, location='view_args', validate=validate.Length(min=4, max=20)),
-            'paramdisplay': fields.String(required=True, validate=validate.OneOf(['all', 'best']))
+            'paramdisplay': fields.String(required=True, validate=validate.OneOf(['all', 'best'])),
+            'cube_extension': fields.String(required=True,
+                                            validate=validate.OneOf(['flux', 'ivar', 'mask']))
             }
 
 # List of all form parameters that are needed in all the API routes
@@ -338,6 +340,3 @@ class ArgValidator(object):
             from werkzeug.datastructures import ImmutableMultiDict
             newargs = ImmutableMultiDict(newargs.copy())
         return newargs
-
-
-

--- a/python/marvin/api/cube.py
+++ b/python/marvin/api/cube.py
@@ -198,7 +198,9 @@ class CubeView(BaseView):
     def getCubeExtension(self, name, cube_extension):
         """Returns the necessary information to instantiate a cube for a given plateifu."""
 
-        cube, res = _getCube(name)
+        # Manually getting the release for now until we fix the problem with the validator.
+        release = request.form.get('release')
+        cube, res = _getCube(name, release=release)
         self.update_results(res)
 
         if cube:

--- a/python/marvin/api/cube.py
+++ b/python/marvin/api/cube.py
@@ -240,6 +240,7 @@ class CubeView(BaseView):
         '''
 
         # Pass the args in and get the cube
+        args = self._pop_args(args, arglist='name')
         cube, res = _getCube(name, **args)
         self.update_results(res)
 

--- a/python/marvin/api/cube.py
+++ b/python/marvin/api/cube.py
@@ -194,17 +194,56 @@ class CubeView(BaseView):
 
     @route('/<name>/extensions/<cube_extension>/', methods=['GET', 'POST'],
            endpoint='getCubeExtension')
-    # @av.check_args()
-    def getCubeExtension(self, name, cube_extension):
-        """Returns the necessary information to instantiate a cube for a given plateifu."""
+    @av.check_args()
+    def getCubeExtension(self, args, name, cube_extension):
+        ''' Returns the 3d flux, ivar, or mask for a cube given a plateifu/mangaid.
 
-        # Manually getting the release for now until we fix the problem with the validator.
-        release = request.form.get('release')
-        cube, res = _getCube(name, release=release)
+        .. :quickref: Cube; Get the full cube 3d flux, ivar, or mask given a plate-ifu or mangaid
+
+        :param name: The name of the cube as plate-ifu or mangaid
+        :param cube_extension: The name of the cube extension.  Either flux, ivar, or mask.
+        :form release: the release of MaNGA
+        :resjson int status: status of response. 1 if good, -1 if bad.
+        :resjson string error: error message, null if None
+        :resjson json inconfig: json of incoming configuration
+        :resjson json utahconfig: json of outcoming configuration
+        :resjson string traceback: traceback of an error, null if None
+        :resjson json data: dictionary of returned data
+        :json string cube_extension: the 3d data for the specified extension
+        :resheader Content-Type: application/json
+        :statuscode 200: no error
+        :statuscode 422: invalid input parameters
+
+        **Example request**:
+
+        .. sourcecode:: http
+
+           GET /marvin2/api/cubes/8485-1901/extensions/flux/ HTTP/1.1
+           Host: api.sdss.org
+           Accept: application/json, */*
+
+        **Example response**:
+
+        .. sourcecode:: http
+
+           HTTP/1.1 200 OK
+           Content-Type: application/json
+           {
+              "status": 1,
+              "error": null,
+              "inconfig": {"release": "MPL-5"},
+              "utahconfig": {"release": "MPL-5", "mode": "local"},
+              "traceback": null,
+              "data": {"cube_extension": ["8485-1901"]
+              }
+           }
+        '''
+
+        # Pass the args in and get the cube
+        cube, res = _getCube(name, **args)
         self.update_results(res)
 
         if cube:
-
             self.results['data'] = {'cube_extension':
                                     cube._getExtensionData(cube_extension.upper()).tolist()}
 

--- a/python/marvin/api/cube.py
+++ b/python/marvin/api/cube.py
@@ -234,7 +234,7 @@ class CubeView(BaseView):
               "inconfig": {"release": "MPL-5"},
               "utahconfig": {"release": "MPL-5", "mode": "local"},
               "traceback": null,
-              "data": {"cube_extension": ["8485-1901"]
+              "data": {"cube_extension": [[0,0,..0], [], ... [0, 0, 0,... 0]]
               }
            }
         '''

--- a/python/marvin/api/cube.py
+++ b/python/marvin/api/cube.py
@@ -4,7 +4,8 @@
 import numpy as np
 
 from flask_classy import route
-from flask import jsonify, request
+from flask import jsonify, request, Response
+import json
 
 from marvin.api.base import BaseView, arg_validate as av
 from marvin.core.exceptions import MarvinError
@@ -191,3 +192,18 @@ class CubeView(BaseView):
 
         return jsonify(self.results)
 
+    @route('/<name>/extensions/<cube_extension>/', methods=['GET', 'POST'],
+           endpoint='getCubeExtension')
+    # @av.check_args()
+    def getCubeExtension(self, name, cube_extension):
+        """Returns the necessary information to instantiate a cube for a given plateifu."""
+
+        cube, res = _getCube(name)
+        self.update_results(res)
+
+        if cube:
+
+            self.results['data'] = {'cube_extension':
+                                    cube._getExtensionData(cube_extension.upper()).tolist()}
+
+        return Response(json.dumps(self.results), mimetype='application/json')

--- a/python/marvin/api/general.py
+++ b/python/marvin/api/general.py
@@ -17,7 +17,7 @@ Revision history:
 from __future__ import division
 from __future__ import print_function
 
-from flask import jsonify
+from flask import jsonify, Response
 from flask_classy import route
 
 from brain.api.general import BrainGeneralRequestsView
@@ -141,7 +141,7 @@ class GeneralRequestsView(BrainGeneralRequestsView):
             self.results['error'] = 'get_nsa_data failed with error: {0}'.format(str(ee))
 
         # these should be jsonify but switching back to json.dumps until fucking Utah gets with the fucking picture
-        return json.dumps(self.results)
+        return Response(json.dumps(self.results), mimetype='application/json')
 
     @route('/nsa/drpall/<mangaid>/', endpoint='nsa_drpall', methods=['GET', 'POST'])
     @av.check_args()
@@ -202,4 +202,4 @@ class GeneralRequestsView(BrainGeneralRequestsView):
             self.results['status'] = -1
             self.results['error'] = 'get_nsa_data failed with error: {0}'.format(str(ee))
 
-        return json.dumps(self.results)
+        return Response(json.dumps(self.results), mimetype='application/json')

--- a/python/marvin/api/query.py
+++ b/python/marvin/api/query.py
@@ -1,5 +1,5 @@
 from flask_classy import route
-from flask import request, jsonify
+from flask import request, jsonify, Response
 from marvin.tools.query import doQuery, Query
 from marvin.core.exceptions import MarvinError
 from marvin.api.base import BaseView, arg_validate as av
@@ -181,7 +181,7 @@ class QueryView(BaseView):
             self.update_results(res)
 
         # this needs to be json.dumps until sas-vm at Utah updates to 2.7.11
-        return json.dumps(self.results)
+        return Response(json.dumps(self.results), mimetype='application/json')
 
     @route('/cubes/getsubset/', methods=['GET', 'POST'], endpoint='getsubset')
     @av.check_args(use_params='query', required=['searchfilter', 'start', 'end'])
@@ -280,7 +280,7 @@ class QueryView(BaseView):
             self.update_results(res)
 
         # this needs to be json.dumps until sas-vm at Utah updates to 2.7.11
-        return json.dumps(self.results)
+        return Response(json.dumps(self.results), mimetype='application/json')
 
     @route('/getparamslist/', methods=['GET', 'POST'], endpoint='getparams')
     @av.check_args(use_params='query', required='paramdisplay')

--- a/python/marvin/db/sql/mangadapdb.sql
+++ b/python/marvin/db/sql/mangadapdb.sql
@@ -62,7 +62,7 @@ create table modelcube (pk serial primary key not null, file_pk integer);
 create table modelspaxel (pk serial primary key not null, flux real[], ivar real[], mask integer[], model real[],
     emline double precision[], emline_base real[], emline_mask integer[], x integer, y integer, modelcube_pk integer);
 
-create table redcorr (pk serial primary key not null, value numeric[], modelcube_pk integer);
+create table redcorr (pk serial primary key not null, value double precision[], modelcube_pk integer);
 
 ALTER TABLE ONLY mangadapdb.file
     ADD CONSTRAINT cube_fk

--- a/python/marvin/tests/tools/test_cube.py
+++ b/python/marvin/tests/tools/test_cube.py
@@ -137,6 +137,16 @@ class TestCube(TestCubeBase):
 
         self.assertTrue(np.allclose(flux, cubeFlux))
 
+    def test_cube_flux_from_api(self):
+
+        cube = Cube(plateifu=self.plateifu, mode='remote')
+        flux = cube.flux
+        self.assertEqual(cube.data_origin, 'api')
+
+        cubeFlux = fits.getdata(self.filename)
+
+        self.assertTrue(np.allclose(flux, cubeFlux, rtol=1e-5))
+
     def test_cube_remote_drpver_differ_from_global(self):
 
         # This tests requires having the cube for 8485-1901 loaded for both

--- a/python/marvin/tools/cube.py
+++ b/python/marvin/tools/cube.py
@@ -86,6 +86,10 @@ class Cube(MarvinToolsClass):
         self.wavelength = None
         self._drpall_data = None
 
+        self._flux = None
+        self._ivar = None
+        self._mask = None
+
         super(Cube, self).__init__(*args, **kwargs)
 
         if self.data_origin == 'file':
@@ -251,17 +255,45 @@ class Cube(MarvinToolsClass):
 
         if self.data_origin == 'file':
             return self.data[extName.upper()].data
+
         elif self.data_origin == 'db':
             return self.data.get3DCube(extName.lower())
-        elif self.data_origin == 'api':
-            raise MarvinError('this feature does not work in remote mode. Use getSpaxel()')
 
-    flux = property(lambda self: self._getExtensionData('FLUX'),
-                    doc='Gets the `FLUX` data extension.')
-    ivar = property(lambda self: self._getExtensionData('IVAR'),
-                    doc='Gets the `IVAR` data extension.')
-    mask = property(lambda self: self._getExtensionData('MASK'),
-                    doc='Gets the `MASK` data extension.')
+        elif self.data_origin == 'api':
+
+            url = marvin.config.urlmap['api']['getCubeExtension']['url']
+
+            try:
+                response = self._toolInteraction(url.format(name=self.plateifu,
+                                                            cube_extension=extName.lower()))
+            except Exception as ee:
+                raise MarvinError('found a problem when checking if remote cube '
+                                  'exists: {0}'.format(str(ee)))
+
+            data = response.getData()
+
+            return np.array(data['cube_extension'])
+
+    @property
+    def flux(self):
+        """Gets the ``FLUX`` data extension."""
+        if not self._flux:
+            self._flux = self._getExtensionData('FLUX')
+        return self._flux
+
+    @property
+    def ivar(self):
+        """Gets the ``IVAR`` data extension."""
+        if not self._ivar:
+            self._ivar = self._getExtensionData('IVAR')
+        return self._ivar
+
+    @property
+    def mask(self):
+        """Gets the ``MASK`` data extension."""
+        if not self._mask:
+            self._mask = self._getExtensionData('MASK')
+        return self._mask
 
     @property
     def qualitybit(self):


### PR DESCRIPTION
This is now implemented in the `flux_api` (regardless of the name of the branch note that this works for flux, ivar, and mask). With a good internet connection, retrieving the flux for a 127-fibre cube takes about 40 seconds, which seems reasonable. The values are cached so the API call will happen only once per extension (flux, ivar, mask).

@havok2063 needs to look into why the `getCubeExtension` in `api/cube.py` does not work with the validators. Also, right now I'm grabbing the release directly from the request instead of using the validator arg.

Fixes #236 