### PR TITLE
Issue #243: inverted `__getitem__` and fixed tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added:
 - Issue #204: added elpetro_absmag colours to mangaSampleDB models.
 ### Changed:
+- Issue #243: inverted `__getitem__` behaviour for Cube/Maps/ModelCube and fixed tests.
 ### Fixed:
 - Interactive prompt for username in sdss_access now works for Python 3.
 - The data file for the default colormap for Map.plot() ("linear_Lab") is now included in pip version of Marvin and does not throw invalid FileNotFoundError if the data file is missing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Interactive prompt for username in sdss_access now works for Python 3.
 - The data file for the default colormap for Map.plot() ("linear_Lab") is now included in pip version of Marvin and does not throw invalid FileNotFoundError if the data file is missing.
 - Fixed #143: prevents access mode to go in to remote if filename is present.
-- Fixed #213: shortcuts are not only applied on full words, to avoid blind replacements.
+- Fixed #213: shortcuts are now only applied on full words, to avoid blind replacements.
 
 ## [2.1.2] - 2017/03/17
 ### Added:

--- a/docs/sphinx/tools/cube.rst
+++ b/docs/sphinx/tools/cube.rst
@@ -19,7 +19,7 @@ Cube
 .. image:: ../_static/spec_8485-1901_17-17.png
 
 
-Here ``cube[17, 17]`` is a shorthand for ``cube.getSpaxel(x=17, y=17, xyorig='lower')``. This returns a :ref:`marvin-tools-spaxel` object. We then use the ``spectrum`` attribute of the :ref:`marvin-tools-spaxel` object to get a :ref:`marvin-tools-spectrum` object that has a ``plot`` method to show the spectrum.
+Here ``cube[i, j]`` is a shorthand for ``cube.getSpaxel(x=j, y=i, xyorig='lower')``. This returns a :ref:`marvin-tools-spaxel` object. We then use the ``spectrum`` attribute of the :ref:`marvin-tools-spaxel` object to get a :ref:`marvin-tools-spectrum` object that has a ``plot`` method to show the spectrum.
 
 If we want the model spectrum, we must explicitly ask for it by setting ``modelcube=True`` when we initialize the :ref:`marvin-tools-spaxel` object.
 

--- a/docs/sphinx/tools/maps.rst
+++ b/docs/sphinx/tools/maps.rst
@@ -22,7 +22,7 @@ Here ``maps['emline_gflux_ha_6564']`` is shorthand for ``maps.getMap('emline_gfl
 To save the plot:
 
 ::
-    
+
     fig.savefig('haflux.pdf')
 
 Version 2.1 introduces a completely refactoring of the :meth:`~marvin.tools.map.Map.plot` method. Please see the `Changelog <https://github.com/sdss/marvin/blob/master/CHANGELOG.md>`_ for a complete list of changes and new options available, but here a few critical default settings that are now used:
@@ -41,10 +41,10 @@ The DAP map data is stored as 2-D arrays in the ``value``, ``ivar``, and ``mask`
 We can also grab the DRP and DAP data on any single spaxel. Let's get the central spaxel (x=17, y=17):
 
 ::
-    
+
     spax = maps[17, 17]
 
-Here ``maps[17, 17]`` is shorthand for ``maps.getSpaxel(x=17, y=17, xyorig='lower')``, which has additional options that can be invoked by using the :meth:`~marvin.tools.maps.Maps.getSpaxel` method. For example, set (``modelcube=True``) to return the model spectrum (``spax.model``).
+Here ``maps[i, j]`` is shorthand for ``maps.getSpaxel(x=j, y=i, xyorig='lower')``, which has additional options that can be invoked by using the :meth:`~marvin.tools.maps.Maps.getSpaxel` method. For example, set (``modelcube=True``) to return the model spectrum (``spax.model``).
 
 We can then get a dictionary of all of the DAP :ref:`marvin-tools-analprop`s with ``spax.properties`` and get the value of any one of them, such as stellar velocity, by using the appropriate key ("stellar_vel" in this case), and accessing the ``value`` attribute of the :ref:`marvin-tools-analprop` object:
 
@@ -77,7 +77,7 @@ By default, :ref:`marvin-tools-maps` selects the unbinned maps ``SPX``, but we c
 * ``ALL`` - all spectra binned together.
 
 ::
-    
+
     maps = Maps(mangaid='1-209232', bintype='VOR10')
 
 Download
@@ -86,7 +86,7 @@ Download
 Download the maps using ``rsync`` via `sdss_access <https://github.com/sdss/sdss_access>`_ (see :ref:`marvin-sdss-depends`):
 
 ::
-    
+
     maps.download()
 
 

--- a/docs/sphinx/tools/modelcube.rst
+++ b/docs/sphinx/tools/modelcube.rst
@@ -14,7 +14,7 @@ ModelCube
 .. image:: ../_static/modelspec_8485-1901_17-17.png
 
 
-Here ``mc[17, 17]`` is a shorthand for ``mc.getSpaxel(x=17, y=17, xyorig='lower')``. This returns a :ref:`marvin-tools-spaxel` object. We then use the ``model`` attribute of the :ref:`marvin-tools-spaxel` object to get a :ref:`marvin-tools-spectrum` object that has a ``plot`` method to show the model spectrum.
+Here ``mc[i, j]`` is a shorthand for ``mc.getSpaxel(x=j, y=i, xyorig='lower')``. This returns a :ref:`marvin-tools-spaxel` object. We then use the ``model`` attribute of the :ref:`marvin-tools-spaxel` object to get a :ref:`marvin-tools-spectrum` object that has a ``plot`` method to show the model spectrum.
 
 ::
 

--- a/docs/sphinx/whats-new.rst
+++ b/docs/sphinx/whats-new.rst
@@ -1,3 +1,15 @@
+What's New in Marvin 2.1.3 (May 2017)
+=====================================
+
+* Slicing in tool objects now behaves as in a Numpy array. That means that `cube[i, j]` returns the same result as `cube.getSpaxel(x=j, y=i, xyorig='lower')`.
+
+* Now it is possible to query on absolute magnitude colours from NSA's `elpetro_absmag`. Absolute magnitudes are now the default for plotting on the web.
+
+* The data file for the default colormap for Map.plot() ("linear_Lab") is now included in pip version of Marvin and does not throw invalid `FileNotFoundError` if the data file is missing.
+
+* Query shortcuts are now only applied on full words, to avoid blind replacements. This fixes a bug that made parameters such as `elpetro_absmag_r` being replaced by `elpetro_absmaelpetro_mag_g_r`.
+
+
 What's New in Marvin 2.1 (February 2017)
 =======================================
 
@@ -82,8 +94,3 @@ The major improvements and additions in this release:
   * Interactive spectrum selection from the galaxy image.
 
   * An image roulette if you are feeling lucky.
-
-
-
-
-

--- a/python/marvin/tests/tools/test_cube.py
+++ b/python/marvin/tests/tools/test_cube.py
@@ -552,9 +552,9 @@ class TestGetSpaxel(TestCubeBase):
         yy = 5
         spec_idx = 200
 
-        spaxel_slice_file = cube_file[xx, yy]
-        spaxel_slice_db = cube_db[xx, yy]
-        spaxel_slice_api = cube_api[xx, yy]
+        spaxel_slice_file = cube_file[yy, xx]
+        spaxel_slice_db = cube_db[yy, xx]
+        spaxel_slice_api = cube_api[yy, xx]
 
         flux_result = 0.017639931
         ivar_result = 352.12421

--- a/python/marvin/tests/tools/test_maps.py
+++ b/python/marvin/tests/tools/test_maps.py
@@ -199,7 +199,7 @@ class TestMapsDB(TestMapsBase):
 
         maps = marvin.tools.maps.Maps(plateifu=self.plateifu, mode='local')
         spaxel = maps.getSpaxel(x=15, y=8, xyorig='lower')
-        spaxel_getitem = maps[15, 8]
+        spaxel_getitem = maps[8, 15]
 
         self.assertTrue(isinstance(spaxel_getitem, marvin.tools.spaxel.Spaxel))
         self.assertIsNotNone(spaxel_getitem.spectrum)

--- a/python/marvin/tests/tools/test_modelcube.py
+++ b/python/marvin/tests/tools/test_modelcube.py
@@ -201,9 +201,9 @@ class TestGetSpaxel(TestModelCubeBase):
         yy = 5
         spec_idx = 200
 
-        spaxel_slice_file = modelcube_file[xx, yy]
-        spaxel_slice_db = modelcube_db[xx, yy]
-        spaxel_slice_api = modelcube_api[xx, yy]
+        spaxel_slice_file = modelcube_file[yy, xx]
+        spaxel_slice_db = modelcube_db[yy, xx]
+        spaxel_slice_api = modelcube_api[yy, xx]
 
         flux_result = 0.016027471050620079
         ivar_result = 361.13595581054693

--- a/python/marvin/tools/cube.py
+++ b/python/marvin/tools/cube.py
@@ -136,7 +136,7 @@ class Cube(MarvinToolsClass):
     def __getitem__(self, xy):
         """Returns the spaxel for ``(x, y)``"""
 
-        return self.getSpaxel(x=xy[0], y=xy[1], xyorig='lower')
+        return self.getSpaxel(x=xy[1], y=xy[0], xyorig='lower')
 
     def _init_attributes(self):
         """Initialises several attributes."""

--- a/python/marvin/tools/maps.py
+++ b/python/marvin/tools/maps.py
@@ -224,7 +224,7 @@ class Maps(marvin.core.core.MarvinToolsClass):
 
         if isinstance(value, tuple):
             assert len(value) == 2, 'slice must have two elements.'
-            x, y = value
+            y, x = value
             return self.getSpaxel(x=x, y=y, xyorig='lower')
         elif isinstance(value, marvin.utils.six.string_types):
             parsed_property = self.properties.get(value)

--- a/python/marvin/tools/modelcube.py
+++ b/python/marvin/tools/modelcube.py
@@ -148,7 +148,7 @@ class ModelCube(MarvinToolsClass):
     def __getitem__(self, xy):
         """Returns the spaxel for ``(x, y)``"""
 
-        return self.getSpaxel(x=xy[0], y=xy[1], xyorig='lower')
+        return self.getSpaxel(x=xy[1], y=xy[0], xyorig='lower')
 
     def _getFullPath(self):
         """Returns the full path of the file in the tree."""


### PR DESCRIPTION
I have inverted `__getitem__` in Cube, Maps, and ModelCube to mean

```python
cube[4, 5] == cube.getSpaxel(x=5, y=4, xyorig='lower')
```

and fixed the tests.

@havok2063 I have had a look at the web and it seems ok. I think slicing is not used in `galaxy.py` but I may be wrong. Can you have a quick look?

This fixes #243