### PR TITLE
Avoid known os.getlogin() bug

### DIFF
--- a/python/marvin/core/exceptions.py
+++ b/python/marvin/core/exceptions.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 import os
 import sys
 import warnings
+import pwd
 
 import marvin
 
@@ -46,7 +47,7 @@ class MarvinSentry(object):
                         )
                 )
             try:
-                self.client.context.merge({'user': {'name': os.getlogin(),
+                self.client.context.merge({'user': {'name': pwd.getpwuid(os.getuid())[0],
                                                     'system': '_'.join(os.uname())}})
             except (OSError, IOError) as ee:
                 warnings.warn('cannot initiate Sentry error reporting: {0}.'.format(str(ee)),


### PR DESCRIPTION
The use of os.getlogin() has known [troubles](https://mail.python.org/pipermail/python-bugs-list/2002-July/012691.html) where the shell can't query the C library's getlogin() (e.g., when run under cron). This tripped on my local linux (Mint 18.3/Ubuntu 16.04+Python3.5) when running under the standard Gnome Terminal. The recommended solution is to use `pwd.getpwuid(os.getuid())[0]`. A quick grock of the codebase only shows this one instance of 'getlogin'.