### PR TITLE
Remove redundant and unmaintainable format checks for version.

### DIFF
--- a/python/marvin/__init__.py
+++ b/python/marvin/__init__.py
@@ -12,7 +12,6 @@ import warnings
 import sys
 import marvin
 from collections import OrderedDict
-from distutils.version import StrictVersion
 
 # Set the Marvin version
 __version__ = '2.2.3dev'
@@ -317,22 +316,12 @@ class MarvinConfig(object):
         self.release = version
 
     def setMPL(self, mplver):
-        """As :func:`setRelease` but check that the version is and MPL."""
-
-        mm = re.search('MPL-([0-9])', mplver)
-        assert mm is not None, 'MPL version must be of form "MPL-[X]"'
-
-        if mm:
-            self.setRelease(mplver)
+        """As :func:`setRelease` but check that the version is an MPL."""
+        self.setRelease(mplver)
 
     def setDR(self, drver):
-        """As :func:`setRelease` but check that the version is and MPL."""
-
-        mm = re.search('DR1([3-9])', drver)
-        assert mm is not None, 'DR version must be of form "DR[XX]"'
-
-        if mm:
-            self.setRelease(drver)
+        """As :func:`setRelease` but check that the version is a DR."""
+        self.setRelease(drver)
 
     def lookUpVersions(self, release=None):
         """Retrieve the DRP and DAP versions that make up a release version.


### PR DESCRIPTION
setMPL and setDR have explicit format checks that are already handled by the version setter in the class These checks would also introduce spurious errors if DR20 or MPL10 were to arrive. This will likely effect #221.

If marvin has a deprecation mechanism, these could be deprecated as setRelease does all of the necessary work.