### PR TITLE
Uses sum of both SII lines for BPT

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Marvin's Change Log
 ===================
 
+
+[2.2.4] - unreleased
+--------------------
+
+Fixed
+^^^^^
+- Issue `#400 <https://github.com/sdss/marvin/issues/400>`: SII in BPT diagram should use sum of 6717 and 6732.
+
+
 [2.2.3] - 2018/03/20
 --------------------
 

--- a/python/marvin/tests/utils/plot/test_map.py
+++ b/python/marvin/tests/utils/plot/test_map.py
@@ -6,7 +6,7 @@
 # @Author: Brett Andrews <andrews>
 # @Date:   2017-05-01 09:07:00
 # @Last modified by:   andrews
-# @Last modified time: 2018-03-20 20:03:12
+# @Last modified time: 2018-04-03 10:04:19
 
 import numpy as np
 import matplotlib
@@ -192,7 +192,7 @@ class TestMapPlot(object):
                               ([35, 35], True, np.array([-17.5, 17.5, -17.5, 17.5])),
                               ([36, 36], False, np.array([0, 35, 0, 35]))])
     def test_set_extent(self, cube_size, sky_coords, expected):
-        extent = mapplot.set_extent(cube_size, sky_coords)
+        extent = mapplot._set_extent(cube_size, sky_coords)
         assert np.all(extent == expected)
 
     @matplotlib_2

--- a/python/marvin/utils/dap/bpt.py
+++ b/python/marvin/utils/dap/bpt.py
@@ -212,7 +212,8 @@ def bpt_kewley06(maps, snr_min=3, return_figure=True, use_oi=True, **kwargs):
             the lines. Alternatively, a dictionary of signal-to-noise values, with the
             emission line channels as keys, can be used.
             E.g., ``snr_min={'ha': 5, 'nii': 3, 'oi': 1}``. If some values are not provided,
-            they will default to ``SNR>=3``.
+            they will default to ``SNR>=3``. Note that the value ``sii`` will be applied to both
+            ``[SII 6718]`` and ``[SII 6732]``.
         return_figure (bool):
             If ``True``, it also returns the matplotlib figure_ of the BPT diagram plot,
             which can be used to modify the style of the plot.
@@ -268,8 +269,11 @@ def bpt_kewley06(maps, snr_min=3, return_figure=True, use_oi=True, **kwargs):
     nii = get_masked(maps, 'nii_6585', snr=get_snr(snr_min, 'nii'))
     ha = get_masked(maps, 'ha_6564', snr=get_snr(snr_min, 'ha'))
     hb = get_masked(maps, 'hb_4862', snr=get_snr(snr_min, 'hb'))
-    sii = get_masked(maps, 'sii_6718', snr=get_snr(snr_min, 'sii'))
     oi = get_masked(maps, 'oi_6302', snr=get_snr(snr_min, 'oi'))
+
+    sii_6718 = get_masked(maps, 'sii_6718', snr=get_snr(snr_min, 'sii'))
+    sii_6732 = get_masked(maps, 'sii_6732', snr=get_snr(snr_min, 'sii'))
+    sii = sii_6718 + sii_6732
 
     # Calculate masked logarithms
     log_oiii_hb = np.ma.log10(oiii / hb)


### PR DESCRIPTION
Fixes #400

This simply uses the sum of both SII lines instead of just SII 6718. No tests seem have been affected by this, which of course means that our tests are not good enough.