### PR TITLE
Provide quick import access to Marvin Tools

### DIFF
--- a/python/marvin/__init__.py
+++ b/python/marvin/__init__.py
@@ -470,3 +470,8 @@ from marvin.api.api import Interaction
 config.sasurl = 'https://api.sdss.org/marvin2/'
 
 from marvin.api.base import arg_validate
+
+# Provide access to base submodules from the marvin namespace
+from . import tools
+from . import db
+from . import utils

--- a/python/marvin/tests/test_imports.py
+++ b/python/marvin/tests/test_imports.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+#
+# @Author: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Date: 2018-07-09
+# @Filename: test_imports.py
+# @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
+#
+# @Last modified by: José Sánchez-Gallego
+# @Last modified time: 2018-07-09 12:11:48
+
+import marvin
+
+
+class TestImports(object):
+
+    def test_access_tools_full_path(self):
+
+        assert marvin.tools.plate.Plate is not None
+        assert marvin.tools.cube.Cube is not None
+        assert marvin.tools.maps.Maps is not None
+        assert marvin.tools.modelcube.ModelCube is not None
+        assert marvin.tools.spaxel.Spaxel is not None
+        assert marvin.tools.spaxel.Bin is not None
+
+    def test_access_tools_from_root(self):
+
+        assert marvin.tools.Plate is not None
+        assert marvin.tools.Cube is not None
+        assert marvin.tools.Maps is not None
+        assert marvin.tools.ModelCube is not None
+        assert marvin.tools.Spaxel is not None
+        assert marvin.tools.Bin is not None

--- a/python/marvin/tools/__init__.py
+++ b/python/marvin/tools/__init__.py
@@ -1,0 +1,6 @@
+from . import cube, maps, modelcube, spaxel
+from .cube import Cube
+from .maps import Maps
+from .modelcube import ModelCube
+from .plate import Plate
+from .spaxel import Bin, Spaxel


### PR DESCRIPTION
I got a bit tired of having to import each tool independently, e.g.

```python
from marvin.tools.cube.Cube
from marvin.tools.maps.Maps
...
```

I have added a few imports in the `__init__.py` so that now everything is accessible from the `marvin` namespace. You can now do

```python
import marvin
my_cube = marvin.tools.cube.Cube('8485-1901')
```

and even

```python
import marvin
my_cube = marvin.tools.Cube('8485-1901')
```

It seems to work fine in Python 2 and 3, doesn't break anything, and it doesn't slow things down as far as I can say. I added a few tests.
