### PR TITLE
Read yanny file only once

### DIFF
--- a/python/marvin/utils/general/maskbit.py
+++ b/python/marvin/utils/general/maskbit.py
@@ -6,7 +6,7 @@
 # @Author: Brett Andrews <andrews>
 # @Date:   2017-10-06 10:10:00
 # @Last modified by: José Sánchez-Gallego
-# @Last modified time: 2018-07-13 08:57:23
+# @Last modified time: 2018-07-13 09:07:21
 
 from __future__ import division, print_function, absolute_import
 
@@ -34,9 +34,9 @@ def _read_maskbit_schemas():
 
     if _maskbits_from_yanny is None:
         path_maskbits = os.path.join(os.path.dirname(marvin.__file__), 'data', 'sdssMaskbits.par')
-        sdss_maskbits = yanny(path_maskbits, np=True)
+        _maskbits_from_yanny = yanny(path_maskbits, np=True)
 
-    return sdss_maskbits['MASKBITS']
+    return _maskbits_from_yanny['MASKBITS']
 
 
 def get_available_maskbits():

--- a/python/marvin/utils/general/maskbit.py
+++ b/python/marvin/utils/general/maskbit.py
@@ -5,8 +5,8 @@
 #
 # @Author: Brett Andrews <andrews>
 # @Date:   2017-10-06 10:10:00
-# @Last modified by:   andrews
-# @Last modified time: 2018-02-22 16:02:75
+# @Last modified by: José Sánchez-Gallego
+# @Last modified time: 2018-07-13 08:57:23
 
 from __future__ import division, print_function, absolute_import
 
@@ -19,14 +19,23 @@ import marvin
 from marvin.utils.general.yanny import yanny
 
 
+# Stores the maskbits yanny file structure so that we don't need to open it more than once.
+_maskbits_from_yanny = None
+
+
 def _read_maskbit_schemas():
     """Read all available SDSS maskbit schemas from yanny file.
 
     Returns:
         Record Array: all bits for all schemas.
     """
-    path_maskbits = os.path.join(os.path.dirname(marvin.__file__), 'data', 'sdssMaskbits.par')
-    sdss_maskbits = yanny(path_maskbits, np=True)
+
+    global _maskbits_from_yanny
+
+    if _maskbits_from_yanny is None:
+        path_maskbits = os.path.join(os.path.dirname(marvin.__file__), 'data', 'sdssMaskbits.par')
+        sdss_maskbits = yanny(path_maskbits, np=True)
+
     return sdss_maskbits['MASKBITS']
 
 


### PR DESCRIPTION
Every time `Maskbits` is called it has to read the maskbits yanny file, which is very slow. This small change stores the yanny file in memory the first time it is read and reuses it from there one. Note that this may be a temporary solution but for now it cuts the import time in half and helps with #442.