### PR TITLE
Fix coordinates bug when loading spaxels in Bin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ Changed
 - Extra keyword arguments passed to ``Spectrum.plot`` are now forwarded to ``Axes.plot``.
 - Tools (e.g., ``Cube``, ``Maps``) can now be accessed from the ``marvin`` namespace (e.g., ``marvin.tools.Cube`` or ``marvin.tools.cube.Cube``).
 
+Fixed
+^^^^^
+- ``Bin._create_spaxels`` instantiating spaxels with the wrong ``(i,j)`` values for the bin. The ``(i, j)`` values from the ``binid`` map were being swapped twice before sending them to ``SpaxelBase`` (:issue:`457`).
+
 
 [2.2.5] - 2018/04/26
 --------------------

--- a/docs/sphinx/whats-new.rst
+++ b/docs/sphinx/whats-new.rst
@@ -1,11 +1,51 @@
 .. _whats-new:
 
-What's New in Marvin 2.2.6 (unreleased)
-=======================================
+What's new in Marvin
+====================
 
+2.2.6 (July 2019)
+------------------
 
-What's New in Marvin 2.2 (January 2018)
-=======================================
+.. attention:: This is a critical bugfix release that corrects a problem that could affect your science results. Please update as soon as possible and check whether your analysis is impacted by this bug.
+
+This version fixes a critical bug when retrieving the spaxels associated with a bin. It also simplifies the library namespace allowing for easier access to the most used Tools.
+
+Spaxels associated with a bin
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In version 2.2 we introduced the concept of :ref:`Bin <marvin-bin>` as a collection of spaxels that belong to the same binning unit. As part of the API, one can use `~marvin.tools.spaxel.Bin.spaxels` attribute to access a list of the spaxels that are included in the bin. The bug now fixed caused a list of incorrect spaxels to be associated with the bin, due to an inversion in the ``(x, y)`` order of the spaxels. For example, *before* 2.2.6 one would get ::
+
+    >>> cube = Cube('8485-1901')
+    >>> maps = cube.getMaps('HYB10')
+    >>> bb = maps[22, 14]
+    >>> bb.spaxels
+    [<Marvin Spaxel (x=21, y=13, loaded=False),
+     <Marvin Spaxel (x=21, y=14, loaded=False),
+     <Marvin Spaxel (x=22, y=13, loaded=False),
+     <Marvin Spaxel (x=22, y=14, loaded=False)]
+
+where the x and y values should be
+
+.. code-block:: console
+
+    [<Marvin Spaxel (x=13, y=21, loaded=False),
+     <Marvin Spaxel (x=14, y=21, loaded=False),
+     <Marvin Spaxel (x=13, y=22, loaded=False),
+     <Marvin Spaxel (x=14, y=22, loaded=False)]
+
+Simplifying the namespace
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Prior to 2.2.6 accessing different Tools classes was inconvenient since one would need to import them independently (e.g., ``from marvin.tools.cube import Cube``, ``from marvin.tools.maps import Maps``, etc.) This version makes access easier by exposing all the Tools from the ``marvin.tools`` namespace so that you can now do ::
+
+    import marvin
+    cube = marvin.tools.Cube('8485-1901')
+    maps = marvin.tools.Maps('7443-12701')
+
+|
+
+2.2 (January 2018)
+------------------
 
 Marvin 2.2.0 brings significant improvements in the way you interact with MaNGA data.  Try the :ref:`Jupyter Notebook<marvin-jupyter-new22>` for a small sample.
 
@@ -21,8 +61,8 @@ Marvin 2.2.0 brings significant improvements in the way you interact with MaNGA 
 
 |
 
-What's New in Marvin 2.1.4 (August 2017)
-========================================
+2.1.4 (August 2017)
+-------------------
 
 * Refactored the Query Page in Marvin Web: Adds more intuitive parameters naming in dropdown.  Adds Guided Marvin Query Builder, using `Jquery Query Builder <http://querybuilder.js.org/>`_.  See the Search page section of :doc:`Web Docs <web>`.
 
@@ -44,8 +84,8 @@ What's New in Marvin 2.1.4 (August 2017)
 
 |
 
-What's New in Marvin 2.1.3 (May 2017)
-=====================================
+2.1.3 (May 2017)
+----------------
 
 * Slicing in tool objects now behaves as in a Numpy array. That means that `cube[i, j]` returns the same result as `cube.getSpaxel(x=j, y=i, xyorig='lower')`.
 
@@ -72,8 +112,8 @@ What's New in Marvin 2.1.3 (May 2017)
 
 |
 
-What's New in Marvin 2.1 (February 2017)
-========================================
+2.1 (February 2017)
+-------------------
 
 * Marvin is now minimally compliant with Python 3.5+
 
@@ -107,8 +147,8 @@ What's New in Marvin 2.1 (February 2017)
 
 |
 
-What's New in Marvin 2.0 Beta (November 2016)
-=============================================
+2.0 Beta (November 2016)
+------------------------
 
 * Brand new painless installation (pip install sdss-marvin)
 
@@ -128,8 +168,8 @@ What's New in Marvin 2.0 Beta (November 2016)
 
 |
 
-What's New in Marvin 2.0 Alpha (June 2016)
-==========================================
+2.0 Alpha (June 2016)
+---------------------
 
 Marvin 2.0 is a complete overhaul of Marvin 1.0, converting Marvin into a full suite of interaction tools.
 

--- a/python/marvin/tests/tools/test_spaxel.py
+++ b/python/marvin/tests/tools/test_spaxel.py
@@ -8,28 +8,22 @@
 # @Copyright: José Sánchez-Gallego
 
 
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
+from __future__ import absolute_import, division, print_function
 
 import itertools
 import os
 
-import pytest
 import astropy.io.fits
+import pytest
 
 from marvin import config
-
 from marvin.core.exceptions import MarvinError
-
-from marvin.tests import marvin_test_if_class
-
+from marvin.tests import marvin_test_if, marvin_test_if_class
 from marvin.tools.cube import Cube
 from marvin.tools.maps import Maps
 from marvin.tools.modelcube import ModelCube
 from marvin.tools.quantities import Spectrum
-from marvin.tools.spaxel import SpaxelBase, Spaxel, Bin
-from marvin.tests import marvin_test_if
+from marvin.tools.spaxel import Bin, Spaxel, SpaxelBase
 
 
 spaxel_modes = [True, False, 'object']
@@ -272,6 +266,21 @@ class TestBin(object):
 
         for sp in bb.spaxels:
             assert sp.loaded is True
+
+    def test_correct_binid(self):
+        """Checks if the binid of the bin spaxels is the correct one (#457)"""
+
+        maps = Maps(plateifu='8485-1901', release='MPL-6', bintype='HYB10')
+        bb = maps[22, 14]
+
+        assert isinstance(bb, Bin)
+        assert bb.x == 14, bb.y == 22
+
+        spaxels = bb.spaxels
+
+        for sp in spaxels:
+            sp_bin = maps[sp.y, sp.x]
+            assert sp_bin.binid == bb.binid
 
 
 class TestPickling(object):

--- a/python/marvin/tools/spaxel.py
+++ b/python/marvin/tools/spaxel.py
@@ -616,7 +616,15 @@ class Spaxel(SpaxelBase):
 
 
 class Bin(SpaxelBase):
-    """A class that represents a bin."""
+    """A class that represents a bin.
+
+    Attributes
+    ----------
+    spaxels : list
+        A list of `.Spaxel` instances that provides access to the unbinned
+        spaxels that are associated with the bin.
+
+    """
 
     def __init__(self, *args, **kwargs):
 
@@ -679,7 +687,7 @@ class Bin(SpaxelBase):
         spaxel_coords = zip(*np.where(binid_map == self.binid))
         self.spaxels = []
 
-        for jj, ii in spaxel_coords:
+        for ii, jj in spaxel_coords:
             self.spaxels.append(Spaxel(x=jj, y=ii, plateifu=self.plateifu, release=self.release,
                                        cube=self._cube, maps=True if self._maps else False,
                                        modelcube=True if self._modelcube else False,


### PR DESCRIPTION
Fixes #457 

This pull request:
- [X] Has a title that summarises what is changing.
- [X] Updates the documentation accordingly.
- [X] Has unit tests & [code coverage](https://coveralls.io/github/sdss/marvin) is not adversely affected (within reason).
- [X] Works with Python 2.7 and 3.6 (and ideally with Python 3.7).
- [X] Updates the [CHANGELOG](https://github.com/sdss/marvin/blob/master/CHANGELOG.rst).
- [ ] Removes more lines of code than it adds.
- [X] If relevant, adds a new entry to the [What's new?](https://github.com/sdss/marvin/blob/master/docs/sphinx/whats-new.rst) page.
