### PR TITLE
Remove targeting bits from SpaxelBase

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Changed
 - Moved ``yanny.py`` to ``extern/`` and added a readme file for the external packages (:issue:`468`).
 - `~marvin.tools.quantities.Spectrum.plot` now only masks part of the spectrum that have the ``DONOTUSE`` maskbit set (:issue:`455`).
 - ``pixmask`` is now available for all quantities (except ``AnalysisProprty``). The property ``masked`` now uses the bit ``DONOTUSE`` to determine what values must be masked out (:issue:`462`).
+- Removes targeting bits from ``Spaxel`` and ``Bin`` (:issue:`465`).
 
 Fixed
 ^^^^^

--- a/python/marvin/tests/tools/test_spaxel.py
+++ b/python/marvin/tests/tools/test_spaxel.py
@@ -382,16 +382,6 @@ class TestMaskbit(object):
         sp = maps.getSpaxel(0, 0, model=True)
         assert len(sp.quality_flags) == 2
 
-    @pytest.mark.parametrize('flag',
-                             ['manga_target1',
-                              'manga_target2',
-                              'manga_target3',
-                              'target_flags'])
-    def test_flag(self, flag, galaxy):
-        maps = Maps(plateifu=galaxy.plateifu)
-        sp = maps[0, 0]
-        assert getattr(sp, flag, None) is not None
-
 
 class TestCubeGetSpaxel(object):
 

--- a/python/marvin/tools/spaxel.py
+++ b/python/marvin/tools/spaxel.py
@@ -538,26 +538,6 @@ class SpaxelBase(six.with_metaclass(SpaxelABC, object)):
         return self._check_versions('template')
 
     @property
-    def manga_target1(self):
-        """Return MANGA_TARGET1 flag."""
-        return self.datamodel.drp.bitmasks['MANGA_TARGET1']
-
-    @property
-    def manga_target2(self):
-        """Return MANGA_TARGET2 flag."""
-        return self.datamodel.drp.bitmasks['MANGA_TARGET2']
-
-    @property
-    def manga_target3(self):
-        """Return MANGA_TARGET3 flag."""
-        return self.datamodel.drp.bitmasks['MANGA_TARGET3']
-
-    @property
-    def target_flags(self):
-        """Bundle MaNGA targeting flags."""
-        return [self.manga_target1, self.manga_target2, self.manga_target3]
-
-    @property
     def quality_flags(self):
         """Bundle Cube DRP3QUAL and Maps DAPQUAL flags."""
 


### PR DESCRIPTION
Fixes #465 

As discussed, this removes the targeting bits (`manga_targetX` and `target_flags`) from `SpaxelBase`.

This pull request:
- [X] Has a title that summarises what is changing.
- [n/a] Updates the documentation accordingly.
- [X] Has unit tests & [code coverage](https://coveralls.io/github/sdss/marvin) is not adversely affected (within reason).
- [X] Works with Python 2.7 and 3.6 (and ideally with Python 3.7).
- [X] Updates the [CHANGELOG](https://github.com/sdss/marvin/blob/master/CHANGELOG.rst).
- [X] Removes more lines of code than it adds.
- [n/a] If relevant, adds a new entry to the [What's new?](https://github.com/sdss/marvin/blob/master/docs/sphinx/whats-new.rst) page.
