### PR TITLE
raises error when applying stellar sigma correction in MPL-6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,8 @@ Changed
 - Moved ``yanny.py`` to ``extern/`` and added a readme file for the external packages (:issue:`468`).
 - `~marvin.tools.quantities.Spectrum.plot` now only masks part of the spectrum that have the ``DONOTUSE`` maskbit set (:issue:`455`).
 - ``pixmask`` is now available for all quantities (except ``AnalysisProprty``). The property ``masked`` now uses the bit ``DONOTUSE`` to determine what values must be masked out (:issue:`462`).
+- Raises error when applying ``inst_sigma_correction`` on ``stellar_sigma`` MPL-6 maps.  Applies correction to stellar_sigma
+and emline_sigma for web maps with added 'Corrected' title (:issue:`478`)
 
 Fixed
 ^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,8 +29,7 @@ Changed
 - Moved ``yanny.py`` to ``extern/`` and added a readme file for the external packages (:issue:`468`).
 - `~marvin.tools.quantities.Spectrum.plot` now only masks part of the spectrum that have the ``DONOTUSE`` maskbit set (:issue:`455`).
 - ``pixmask`` is now available for all quantities (except ``AnalysisProprty``). The property ``masked`` now uses the bit ``DONOTUSE`` to determine what values must be masked out (:issue:`462`).
-- Raises error when applying ``inst_sigma_correction`` on ``stellar_sigma`` MPL-6 maps.  Applies correction to stellar_sigma
-and emline_sigma for web maps with added 'Corrected' title (:issue:`478`)
+- Raises error when applying ``inst_sigma_correction`` on ``stellar_sigma`` MPL-6 maps.  Applies correction to stellar_sigma and emline_sigma for web maps with added 'Corrected' title (:issue:`478`)
 
 Fixed
 ^^^^^

--- a/docs/sphinx/known-issues.rst
+++ b/docs/sphinx/known-issues.rst
@@ -11,6 +11,9 @@ Known Issues in Marvin
 .. _report new issue: https://github.com/sdss/marvin/issues/new
 
 
+* **Sigma Corrections**:
+  For MPL-6, we now raise an explicit error when attempting to apply the correction to `stellar_sigma`, using the `inst_sigma_correction` method.  The error message now suggests to upgrade to MPL-7 data.  In the web display of maps, when selecting the ``stellar_sigma`` or ``emline_sigma`` maps, we automatically apply the relevant sigma correction.  A corrected map is indicated via the **Corrected: [name]** map title.  Uncorrected maps, for example, in MPL-6, retain the original title name.
+
 * **Marvin 2.2.1 MPL-6 Maps** - All H-alpha extensions in the Marvin MAPS, using MPL-6, map to NII_6585 extensions instead.  Additionally, the Marvin Maps for SPX_ELLCOO and BIN_LWELLCOO do not include the new channel R/Reff.  It is advisable to upgrade to Marvin 2.2.2, where these bugs have been fixed.
 
 

--- a/docs/sphinx/web.rst
+++ b/docs/sphinx/web.rst
@@ -181,6 +181,9 @@ flux map, and the d4000 spectral index map.  All maps are generated using the
   * **Get Maps**: Click to display maps.
   * **Reset Selection**: Clear your selected Analysis Properties (Binning Scheme and Stellar Template combination will remain the same.).
 
+* **Sigma Corrections**:
+  When selecting the ``stellar_sigma`` or ``emline_sigma`` maps, we automatically apply the relevant sigma correction.  A corrected map is indicated via the **Corrected: [name]** map title.  Uncorrected maps, for example, in MPL-6, retain the original title name.
+
 * **Map Color Schemes**:
 
   * **No Data and Bad Data**

--- a/docs/sphinx/whats-new.rst
+++ b/docs/sphinx/whats-new.rst
@@ -46,6 +46,11 @@ Prior to 2.2.6 accessing different Tools classes was inconvenient since one woul
     cube = marvin.tools.Cube('8485-1901')
     maps = marvin.tools.Maps('7443-12701')
 
+Stellar Sigma Correction
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+For MPL-6, we now raise an explicit error when attempting to apply the correction to `stellar_sigma`, using the `inst_sigma_correction` method.  The error message now suggests to upgrade to MPL-7 data.  For the web display of the `stellar_sigma` and `emline_gsigma` maps, we now apply the sigma correction automatically.  The corrected map is indicated via **Corrected: stellar_sigma** map title.
+
 |
 
 2.2 (January 2018)

--- a/python/marvin/core/exceptions.py
+++ b/python/marvin/core/exceptions.py
@@ -112,11 +112,16 @@ class MarvinWarning(Warning):
 
 class MarvinUserWarning(UserWarning, MarvinWarning):
     """The primary warning class."""
+    pass
+
+
+class MarvinPassiveAggressiveWarning(MarvinUserWarning):
+    """The passive aggressive warning class."""
 
     def __init__(self, message=None):
         message = ("Well, I wouldn't do it like that, but if that's "
                    "how you want to do it, sure, go ahead.\n{0}".format(message or ''))
-        super(MarvinUserWarning, self).__init__(message)
+        super(MarvinPassiveAggressiveWarning, self).__init__(message)
 
 
 class MarvinSkippedTestWarning(MarvinUserWarning):

--- a/python/marvin/db/models/DapModelClasses.py
+++ b/python/marvin/db/models/DapModelClasses.py
@@ -194,7 +194,7 @@ class Structure(Base):
     __table_args__ = {'autoload': True, 'schema': 'mangadapdb'}
 
     def __repr__(self):
-        return '<Structure (pk={0})'.format(self.pk)
+        return '<Structure (pk={0}, bintype={1}, template={3})'.format(self.pk, self.bintype.name, self.template_kin.name)
 
 
 class BinId(Base):

--- a/python/marvin/tests/tools/test_map.py
+++ b/python/marvin/tests/tools/test_map.py
@@ -6,7 +6,7 @@
 # @Filename: test_map.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
-# @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Last modified by:   Brian Cherinka
 # @Last modified time: 2018-07-20 19:12:32
 
 
@@ -387,7 +387,7 @@ class TestMapArith(object):
         assert map_new.ivar == pytest.approx(ivar_new)
         assert (map_new.mask == map_orig.mask).all()
 
-    @marvin_test_if(mark='skip', galaxy=dict(release=['MPL-4']))
+    @marvin_test_if(mark='skip', galaxy=dict(release=['MPL-4', 'MPL-6']))
     def test_stellar_sigma_correction(self, galaxy):
         maps = Maps(plateifu=galaxy.plateifu)
         stsig = maps['stellar_sigma']
@@ -406,14 +406,20 @@ class TestMapArith(object):
         assert (actual.mask == expected.mask).all()
         assert actual.datamodel == stsig.datamodel
 
-    @marvin_test_if(mark='include', galaxy=dict(release=['MPL-4']))
+    @marvin_test_if(mark='include', galaxy=dict(release=['MPL-4', 'MPL-6']))
     def test_stellar_sigma_correction_MPL4(self, galaxy):
         maps = Maps(plateifu=galaxy.plateifu)
         stsig = maps['stellar_sigma']
+
+        if galaxy.release == 'MPL-4':
+            errmsg = 'Instrumental broadening correction not implemented for MPL-4.'
+        elif galaxy.release == 'MPL-6':
+            errmsg = 'The stellar sigma corrections in MPL-6 are wrong. Please upgrade to MPL-7.'
+
         with pytest.raises(MarvinError) as ee:
             stsig.inst_sigma_correction()
 
-        assert 'Instrumental broadening correction not implemented for MPL-4.' in str(ee.value)
+        assert errmsg in str(ee.value)
 
     def test_stellar_sigma_correction_invalid_property(self, galaxy):
         maps = Maps(plateifu=galaxy.plateifu)

--- a/python/marvin/tests/web/test_galaxy.py
+++ b/python/marvin/tests/web/test_galaxy.py
@@ -10,8 +10,8 @@
 
 from __future__ import print_function, division, absolute_import
 from marvin.web.controllers.galaxy import make_nsa_dict
+from marvin.web.controllers.galaxy import getWebMap
 from marvin.tools.cube import Cube
-from marvin import config
 from marvin.tests.conftest import set_the_config
 import pytest
 
@@ -61,5 +61,31 @@ class TestNSA(object):
         page.load_page('post', page.url)
         template, context = get_templates[0]
         page.route_no_valid_webparams(template, context, 'plateifu', reqtype='post', errmsg=errmsg)
+
+
+class TestWebMap(object):
+
+    @pytest.mark.parametrize('parameter, channel',
+                             [('emline_gflux', 'ha_6564'),
+                              ('emline_gsigma', 'ha_6564'),
+                              ('stellar_sigma', None)],
+                             ids=['gflux', 'gsigma', 'stellarsigma'])
+    def test_getmap(self, cube, parameter, channel):
+        webmap, mapmsg = getWebMap(cube, parameter=parameter, channel=channel)
+
+        assert isinstance(webmap, dict)
+        assert 'values' in webmap
+        assert isinstance(webmap['values'], list)
+        assert parameter in mapmsg
+        if 'sigma' in parameter and cube.release != 'MPL-6':
+            assert 'Corrected' in mapmsg
+
+    def test_getmap_failed(self, cube):
+        webmap, mapmsg = getWebMap(cube, parameter='crap')
+        assert webmap is None
+        assert 'Could not get map' in mapmsg
+
+
+
 
 

--- a/python/marvin/tools/maps.py
+++ b/python/marvin/tools/maps.py
@@ -6,7 +6,7 @@
 # @Filename: maps.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
-# @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Last modified by:   Brian Cherinka
 # @Last modified time: 2018-07-20 18:25:03
 
 
@@ -593,6 +593,11 @@ class Maps(MarvinToolsClass, NSAMixIn, DAPallMixIn, GetApertureMixIn):
             best = property_name
         else:
             best = self._match_properties(property_name, channel=channel, exact=exact)
+
+        # raise error when property is MPL-6 stellar_sigmacorr
+        if best.full() == 'stellar_sigmacorr' and self.release == 'MPL-6':
+            raise marvin.core.exceptions.MarvinError('stellar_sigmacorr is unreliable in MPL-6. '
+                                                     'Please use MPL-7.')
 
         return marvin.tools.quantities.Map.from_maps(self, best)
 

--- a/python/marvin/tools/quantities/map.py
+++ b/python/marvin/tools/quantities/map.py
@@ -520,7 +520,7 @@ class Map(units.Quantity, QuantityMixIn):
                     'Instrumental broadening correction not implemented for MPL-4.')
             elif 'MPL-6' in self._datamodel.parent.aliases:
                 raise marvin.core.exceptions.MarvinError(
-                    'The stellar sigma corrections in MPL-6 are unreliable. Please use to MPL-7.')
+                    'The stellar sigma corrections in MPL-6 are unreliable. Please use MPL-7.')
 
             map_corr = self.getMaps()['stellar_sigmacorr']
 

--- a/python/marvin/tools/quantities/map.py
+++ b/python/marvin/tools/quantities/map.py
@@ -520,7 +520,7 @@ class Map(units.Quantity, QuantityMixIn):
                     'Instrumental broadening correction not implemented for MPL-4.')
             elif 'MPL-6' in self._datamodel.parent.aliases:
                 raise marvin.core.exceptions.MarvinError(
-                    'The stellar sigma corrections in MPL-6 are wrong. Please upgrade to MPL-7.')
+                    'The stellar sigma corrections in MPL-6 are unreliable. Please use to MPL-7.')
 
             map_corr = self.getMaps()['stellar_sigmacorr']
 

--- a/python/marvin/tools/quantities/map.py
+++ b/python/marvin/tools/quantities/map.py
@@ -6,7 +6,7 @@
 # @Filename: map.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
-# @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Last modified by:   Brian Cherinka
 # @Last modified time: 2018-07-22 02:10:42
 
 
@@ -512,11 +512,15 @@ class Map(units.Quantity, QuantityMixIn):
         Correct observed stellar or emission line velocity dispersion
         for instrumental broadening.
         """
+
         if self.datamodel.name == 'stellar_sigma':
 
-            if self._datamodel.parent.release == 'MPL-4':
+            if 'MPL-4' in self._datamodel.parent.aliases:
                 raise marvin.core.exceptions.MarvinError(
                     'Instrumental broadening correction not implemented for MPL-4.')
+            elif 'MPL-6' in self._datamodel.parent.aliases:
+                raise marvin.core.exceptions.MarvinError(
+                    'The stellar sigma corrections in MPL-6 are wrong. Please upgrade to MPL-7.')
 
             map_corr = self.getMaps()['stellar_sigmacorr']
 
@@ -543,7 +547,7 @@ class Map(units.Quantity, QuantityMixIn):
         """
         if self.datamodel.name == 'specindex':
 
-            if self._datamodel.parent.release == 'MPL-4':
+            if 'MPL-4' in self._datamodel.parent.aliases:
                 raise marvin.core.exceptions.MarvinError(
                     'Velocity dispersion correction not implemented for MPL-4.')
 

--- a/python/marvin/utils/general/general.py
+++ b/python/marvin/utils/general/general.py
@@ -783,6 +783,8 @@ def downloadList(inputlist, dltype='cube', **kwargs):
         NA: Downloads
     """
 
+    assert isinstance(inputlist, (list, np.ndarray)), 'inputlist must be a list or numpy array'
+
     # Get some possible keywords
     # Necessary rsync variables:
     #   drpver, plate, ifu, dir3d, [mpl, dapver, bintype, n, mode]

--- a/python/marvin/web/controllers/galaxy.py
+++ b/python/marvin/web/controllers/galaxy.py
@@ -82,12 +82,26 @@ def getWebSpectrum(cube, x, y, xyorig=None, byradec=False):
 def getWebMap(cube, parameter='emline_gflux', channel='ha_6564',
               bintype=None, template=None):
     ''' Get and format a map for the web '''
-    name = '{0}_{1}'.format(parameter.lower(), channel)
+    if channel:
+        name = '{0}_{1}'.format(parameter.lower(), channel)
+    else:
+        name = '{0}'.format(parameter.lower())
+
     webmap = None
     try:
         maps = cube.getMaps(plateifu=cube.plateifu, mode='local',
                             bintype=bintype, template=template)
         data = maps.getMap(parameter, channel=channel)
+
+        # correct the stellar_sigma or emline_gsigma maps
+        if parameter == 'stellar_sigma' or parameter == 'emline_gsigma':
+            try:
+                data = data.inst_sigma_correction()
+            except MarvinError as e:
+                pass
+            else:
+                name = 'Corrected {0}'.format(name)
+
     except Exception as e:
         mapmsg = 'Could not get map: {0}'.format(e)
     else:

--- a/python/marvin/web/controllers/galaxy.py
+++ b/python/marvin/web/controllers/galaxy.py
@@ -150,7 +150,8 @@ def buildMapDict(cube, params, dapver, bintemp=None):
 
     anybad = [m['data'] is None for m in mapdict]
     if any(anybad):
-        raise MarvinError('Could not get map for one of supplied parameters')
+        bad_params = ', '.join([p for i, p in enumerate(params) if anybad[i]])
+        raise MarvinError('Could not get map for: {0}.  Please select another.'.format(bad_params))
 
     return mapdict
 


### PR DESCRIPTION
Also applies the correction to the `stellar_sigma` and `emline_gsigma` web maps.  Adds 'Corrected' to the map title.  

Fixes #478

This pull request:
- [X] Has a title that summarises what is changing.
- [X] Updates the documentation accordingly.
- [X] Has unit tests & [code coverage](https://coveralls.io/github/sdss/marvin) is not adversely affected (within reason).
- [X] Works with Python 2.7 and 3.6 (and ideally with Python 3.7).
- [X] Updates the [CHANGELOG](https://github.com/sdss/marvin/blob/master/CHANGELOG.rst).
- [X] Removes more lines of code than it adds.
- [X] If relevant, adds a new entry to the [What's new?](https://github.com/sdss/marvin/blob/master/docs/sphinx/whats-new.rst) page.
