### PR TITLE
Fix for bug when explicitly returning default parameters in query

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,7 @@ Fixed
 - Issue `#431 <https://github.com/sdss/marvin/issues/431>`_ - adding login documentation
 - Issue `#151 <https://github.com/sdss/marvin/issues/151>`_ - adding web spectrum tooltips
 - Fixed typo by in method name ``Spectrum.derredden -> Spectrum.deredden``.
+- A bug when explicitly returning default parameters in a query (:issue:`484`)
 
 Refactored
 ^^^^^^^^^^

--- a/python/marvin/db/models/DapModelClasses.py
+++ b/python/marvin/db/models/DapModelClasses.py
@@ -432,4 +432,8 @@ dap_cache = RelationshipCache(File.cube).\
 for classname, class_model in spaxel_tables.items():
     dap_cache = dap_cache.and_(RelationshipCache(class_model.file))
 
+# delete extra classes from the various loops
+del class_model
+del cleanclass
+del newclass
 

--- a/python/marvin/tests/conftest.py
+++ b/python/marvin/tests/conftest.py
@@ -6,7 +6,7 @@
 # @Filename: conftest.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
-# @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Last modified by:   Brian Cherinka
 # @Last modified time: 2018-07-21 21:51:06
 
 import copy
@@ -632,7 +632,7 @@ def maps_release_only(release):
 
 
 @pytest.fixture(scope='function')
-def query(request, release, mode, db):
+def query(request, monkeyauth, release, mode, db):
     ''' Yields a Query that loops over all modes and db options '''
     data = query_data[release]
     set_the_config(release)

--- a/python/marvin/tests/tools/test_query.py
+++ b/python/marvin/tests/tools/test_query.py
@@ -6,7 +6,7 @@
 # @Author: Brian Cherinka
 # @Date:   2017-05-25 10:11:21
 # @Last modified by:   Brian Cherinka
-# @Last Modified time: 2018-07-14 12:33:05
+# @Last Modified time: 2018-07-24 17:30:24
 
 from __future__ import print_function, division, absolute_import
 from marvin.tools.query import Query, doQuery
@@ -182,6 +182,16 @@ class TestQueryReturnParams(object):
             res = query.run()
         assert cm.type == error
         assert errmsg in str(cm.value)
+
+    @pytest.mark.parametrize('query', [('nsa.z < 0.1')], indirect=True)
+    @pytest.mark.parametrize('rps', [(['absmag_g_r', 'cube.plate', 'cube.plateifu'])])
+    def test_skipdefault(self, query, rps):
+        query = Query(searchfilter=query.searchfilter, returnparams=rps, mode=query.mode)
+        assert len(query._returnparams) == len(rps)
+        assert len(query.params) == 6
+        res = query.run()
+        assert len(res.returnparams) == len(rps)
+        assert len(res.columns) == 6
 
 
 class TestQueryReturnType(object):

--- a/python/marvin/tools/query.py
+++ b/python/marvin/tools/query.py
@@ -351,7 +351,11 @@ class Query(object):
                                  for rp in returnparams]
 
             self._returnparams = full_returnparams
-        self.params.extend(full_returnparams)
+
+        # remove any return parameters that are also defaults
+        use_only = [f for f in full_returnparams if f not in self.defaultparams]
+
+        self.params.extend(use_only)
 
     def set_defaultparams(self):
         ''' Loads the default params for a given return type

--- a/python/marvin/tools/results.py
+++ b/python/marvin/tools/results.py
@@ -5,32 +5,33 @@
 #
 
 from __future__ import print_function
-from marvin.core.exceptions import MarvinError, MarvinUserWarning, MarvinBreadCrumb
-from marvin.tools.cube import Cube
-from marvin.tools.maps import Maps
-from marvin.tools.rss import RSS
-from marvin.tools.modelcube import ModelCube
-from marvin.tools.spaxel import Spaxel
-from marvin.utils.datamodel.query import datamodel
-from marvin.utils.datamodel.query.base import ParameterGroup
-from marvin import config, log
-from marvin.utils.general import getImagesByList, downloadList, map_bins_to_column
-from marvin.utils.general import temp_setattr, turn_off_ion
-from marvin.api.api import Interaction
-from marvin.core import marvin_pickle
-import marvin.utils.plot.scatter
-from operator import add
-import warnings
+
+import copy
+import datetime
 import json
 import os
-import datetime
+import warnings
+from collections import namedtuple
+from functools import wraps
+from operator import add
+
 import numpy as np
 import six
-import copy
+from astropy.table import Table, hstack, vstack
 from fuzzywuzzy import process
-from functools import wraps
-from astropy.table import Table, vstack, hstack
-from collections import namedtuple
+import marvin.utils.plot.scatter
+from marvin import config, log
+from marvin.api.api import Interaction
+from marvin.core import marvin_pickle
+from marvin.core.exceptions import (MarvinBreadCrumb, MarvinError, MarvinUserWarning)
+from marvin.tools.cube import Cube
+from marvin.tools.maps import Maps
+from marvin.tools.modelcube import ModelCube
+from marvin.tools.rss import RSS
+from marvin.utils.datamodel.query import datamodel
+from marvin.utils.datamodel.query.base import ParameterGroup
+from marvin.utils.general import (downloadList, getImagesByList, map_bins_to_column, temp_setattr,
+                                  turn_off_ion)
 
 try:
     import cPickle as pickle
@@ -1429,7 +1430,7 @@ class Results(object):
 
         print('Converting results to Marvin {0} objects'.format(tooltype.title()))
         if tooltype == 'cube':
-            self.objects = [Cube(plateifu=res.plateifu, mode=mode) for res in self.results[0:limit]]
+            self.objects = [self._get_object(Cube, plateifu=res.plateifu, mode=mode) for res in self.results[0:limit]]
         elif tooltype == 'maps':
 
             isbin = 'bintype.name' in paramlist
@@ -1447,7 +1448,7 @@ class Results(object):
                     tempval = res.template_name
                     mapkwargs['template_kin'] = tempval
 
-                self.objects.append(Maps(**mapkwargs))
+                self.objects.append(self._get_object(Maps, **mapkwargs))
         elif tooltype == 'spaxel':
 
             assert 'spaxelprop.x' in paramlist and 'spaxelprop.y' in paramlist, \
@@ -1455,22 +1456,18 @@ class Results(object):
 
             self.objects = []
 
-            load = kwargs.get('load', True)
-            maps = kwargs.get('maps', True)
-            modelcube = kwargs.get('modelcube', True)
-
             tab = self.toTable()
             uniq_plateifus = list(set(self.getListOf('plateifu')))
 
             for plateifu in uniq_plateifus:
-                c = Cube(plateifu=plateifu, mode=mode)
+                c = self._get_object(Cube, plateifu=plateifu, mode=mode)
                 univals = tab['cube.plateifu'] == plateifu
                 x = tab[univals]['spaxelprop.x'].tolist()
                 y = tab[univals]['spaxelprop.y'].tolist()
                 spaxels = c[y, x]
                 self.objects.extend(spaxels)
         elif tooltype == 'rss':
-            self.objects = [RSS(plateifu=res.plateifu, mode=mode) for res in self.results[0:limit]]
+            self.objects = [self._get_object(RSS, plateifu=res.plateifu, mode=mode) for res in self.results[0:limit]]
         elif tooltype == 'modelcube':
 
             isbin = 'bintype.name' in paramlist
@@ -1488,7 +1485,31 @@ class Results(object):
                     tempval = res.template_name
                     mapkwargs['template_kin'] = tempval
 
-                self.objects.append(ModelCube(**mapkwargs))
+                self.objects.append(self._get_object(ModelCube, **mapkwargs))
+
+    def _get_object(self, obj, **kwargs):
+        ''' Return a Marvin object or an error message
+
+        To preserve the lengths of self.results and self.objects, it will
+        either return an instance or an error message in its place
+
+        Parameters:
+            obj (object):
+                A Marvin Class object
+            kwargs:
+                Any set of parameters to instantiate a Marvin object
+
+        Returns:
+            The Marvin instance or an error message if it failed
+        '''
+
+        try:
+            inst = obj(**kwargs)
+        except MarvinError as e:
+            plateifu = kwargs.get('plateifu', '')
+            inst = 'Error creating {0} for {1}: {2}'.format(obj.__name__, plateifu, e)
+        else:
+            return inst
 
     def plot(self, x_name, y_name, **kwargs):
         ''' Make a scatter plot from two columns of results
@@ -1621,4 +1642,3 @@ class Results(object):
             output = (hdata,) + output[1:] if return_figure else hdata
 
         return output
-

--- a/python/marvin/utils/datamodel/query/MPL.py
+++ b/python/marvin/utils/datamodel/query/MPL.py
@@ -6,7 +6,7 @@
 # @Author: Brian Cherinka
 # @Date:   2017-09-20 13:24:13
 # @Last modified by:   Brian Cherinka
-# @Last Modified time: 2018-04-10 15:28:51
+# @Last Modified time: 2018-07-24 18:09:03
 
 from __future__ import print_function, division, absolute_import
 from .base import QueryDataModel
@@ -21,7 +21,7 @@ def groups():
 # MPL-4
 
 # list of tables to exclude
-BASE_EXCLUDE = ['anime', 'catalogue', 'pipeline', 'maskbit', 'hdu', 'query',
+BASE_EXCLUDE = ['anime', 'catalogue', 'pipeline', 'maskbit', 'hdu', 'query', 'user',
                 'extcol', 'exttype', 'extname', 'cube_shape', 'spaxelprops']
 
 EXCLUDE = ['modelcube', 'modelspaxel', 'redcorr', 'obsinfo', 'dapall'] + BASE_EXCLUDE


### PR DESCRIPTION
Fixes #484.  In addition, bug fixes the query datamodel and modelclasses to eliminate new extraneous parameters.  This fixes many prior broken query tests.  Also includes additional fixes for in `Results.convertToTool` to fix tests.  There are three remaining MPL-4 query tests that fail due to #482.

This pull request:
- [X] Has a title that summarises what is changing.
- [ ] Updates the documentation accordingly.
- [X] Has unit tests & [code coverage](https://coveralls.io/github/sdss/marvin) is not adversely affected (within reason).
- [X] Works with Python 2.7 and 3.6 (and ideally with Python 3.7).
- [X] Updates the [CHANGELOG](https://github.com/sdss/marvin/blob/master/CHANGELOG.rst).
- [X] Removes more lines of code than it adds.
- [ ] If relevant, adds a new entry to the [What's new?](https://github.com/sdss/marvin/blob/master/docs/sphinx/whats-new.rst) page.
