### PR TITLE
Add mask parameter to getSpaxels

### DIFF
--- a/python/marvin/tests/tools/test_aperture.py
+++ b/python/marvin/tests/tools/test_aperture.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2018-07-17 16:39:15
+# @Last modified time: 2018-07-27 13:06:25
 
 import numpy
 import pytest
@@ -108,3 +108,16 @@ def test_get_aperture_no_lazy():
     aperture = cube.getAperture((17, 17), 1)
 
     assert aperture.getSpaxels(lazy=False)[0].loaded is True
+
+
+def test_get_spaxels_custom_mask():
+    """Tests the mask parameter in getSpaxels."""
+
+    cube = marvin.tools.Cube('8485-1901')
+
+    aperture = cube.getAperture((17, 17), 2)
+
+    my_mask = aperture.mask.copy()
+    my_mask[0:5, 0:5] = 1
+
+    assert len(aperture.getSpaxels(mask=my_mask)) == 34

--- a/python/marvin/tools/mixins/aperture.py
+++ b/python/marvin/tools/mixins/aperture.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2018-07-14 21:49:28
+# @Last modified time: 2018-07-27 13:02:19
 
 import astropy.coordinates
 import astropy.units
@@ -69,7 +69,7 @@ class MarvinAperture(photutils.Aperture if photutils else object):
 
         return mask
 
-    def getSpaxels(self, threshold=0.5, lazy=True, **kwargs):
+    def getSpaxels(self, threshold=0.5, lazy=True, mask=None, **kwargs):
         """Returns the spaxels that fall within the aperture.
 
         Parameters
@@ -80,6 +80,10 @@ class MarvinAperture(photutils.Aperture if photutils else object):
         lazy : bool
             Whether the returned spaxels must be fully loaded or lazily
             instantiated.
+        mask : numpy.ndarray
+            A mask that defines the fractional pixel overlap with the
+            apertures. If ``None``, the mask returned by `.MarvinAperture.mask`
+            will be used.
         kwargs : dict
             Additional parameters to be passed to the parent ``getSpaxel``
             method. Can be used to define what information is loaded
@@ -89,7 +93,11 @@ class MarvinAperture(photutils.Aperture if photutils else object):
 
         assert threshold > 0 and threshold <= 1, 'invalid threshold value'
 
-        mask = self.mask
+        if mask is None:
+            mask = self.mask
+        else:
+            assert mask.shape == self.parent._shape, 'invalid mask shape'
+
         spaxel_coords = numpy.where(mask >= threshold)
 
         if len(spaxel_coords[0]) == 0:


### PR DESCRIPTION
Fixes #493 

This pull request:
- [X] Has a title that summarises what is changing.
- [X] Updates the documentation accordingly (already done in `tools-doc-reorg`).
- [X] Has unit tests & [code coverage](https://coveralls.io/github/sdss/marvin) is not adversely affected (within reason).
- [X] Works with Python 2.7 and 3.6 (and ideally with Python 3.7).
- [n/a] Updates the [CHANGELOG](https://github.com/sdss/marvin/blob/master/CHANGELOG.rst).
- [ ] Removes more lines of code than it adds.
- [ ] If relevant, adds a new entry to the [What's new?](https://github.com/sdss/marvin/blob/master/docs/sphinx/whats-new.rst) page.
