### PR TITLE
Fixes bug in map plotting using sky coordinates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,7 @@ Fixed
 - Issue `#151 <https://github.com/sdss/marvin/issues/151>`_ - adding web spectrum tooltips
 - Fixed typo by in method name ``Spectrum.derredden -> Spectrum.deredden``.
 - A bug when explicitly returning default parameters in a query (:issue:`484`)
+- Fixed `#510 <https://github.com/sdss/marvin/issues/510>`_ - fixes incorrect conversion to sky coordinates in map plotting.
 
 Refactored
 ^^^^^^^^^^

--- a/python/marvin/tests/utils/plot/test_map.py
+++ b/python/marvin/tests/utils/plot/test_map.py
@@ -7,7 +7,7 @@
 # @Date:   2017-05-01 09:07:00
 
 # @Last modified by:   andrews
-# @Last modified time: 2018-07-06 15:07:79
+# @Last modified time: 2018-08-07 16:08:15
 
 import numpy as np
 import matplotlib
@@ -189,8 +189,8 @@ class TestMasks(object):
 class TestMapPlot(object):
 
     @pytest.mark.parametrize('cube_size, sky_coords, expected',
-                             [([36, 36], True, np.array([-18, 18, -18, 18])),
-                              ([35, 35], True, np.array([-17.5, 17.5, -17.5, 17.5])),
+                             [([36, 36], True, np.array([-9, 9, -9, 9])),
+                              ([35, 35], True, np.array([-8.75, 8.75, -8.75, 8.75])),
                               ([36, 36], False, np.array([0, 35, 0, 35]))])
     def test_set_extent(self, cube_size, sky_coords, expected):
         extent = mapplot._set_extent(cube_size, sky_coords)

--- a/python/marvin/utils/plot/map.py
+++ b/python/marvin/utils/plot/map.py
@@ -190,8 +190,8 @@ def _set_extent(cube_size, sky_coords):
     """
     if sky_coords:
         spaxel_size = 0.5  # arcsec
-        extent = np.array([-(cube_size[0] * spaxel_size), (cube_size[0] * spaxel_size),
-                           -(cube_size[1] * spaxel_size), (cube_size[1] * spaxel_size)])
+        extent = np.array([-(cube_size[0] / 2 * spaxel_size), (cube_size[0] / 2 * spaxel_size),
+                           -(cube_size[1] / 2 * spaxel_size), (cube_size[1] / 2 * spaxel_size)])
     else:
         extent = np.array([0, cube_size[0] - 1, 0, cube_size[1] - 1])
 


### PR DESCRIPTION
Fixes #510 

This pull request:
- [x] Has a title that summarises what is changing.
- [x] Updates the documentation accordingly.
- [x] Has unit tests & [code coverage](https://coveralls.io/github/sdss/marvin) is not adversely affected (within reason).
- [x] Works with Python 2.7 and 3.6 (and ideally with Python 3.7).
- [x] Updates the [CHANGELOG](https://github.com/sdss/marvin/blob/master/CHANGELOG.rst).
- [ ] Removes more lines of code than it adds.
- [ ] If relevant, adds a new entry to the [What's new?](https://github.com/sdss/marvin/blob/master/docs/sphinx/whats-new.rst) page.

The conversion of spaxel coordinates to sky coordinates incorrectly resulted in sky coordinates that were too large by a factor of 2. This is now fixed.