### PR TITLE
Cast keys to a list to avoid error when key list changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,6 +65,7 @@ Fixed
 - Fixed `#305 <https://github.com/sdss/marvin/issues/305>`_ - adding ivar propogation for np.log10(Map)
 - A bug when explicitly returning default parameters in a query (:issue:`484`)
 - Fixed `#510 <https://github.com/sdss/marvin/issues/510>`_ - fixes incorrect conversion to sky coordinates in map plotting.
+- Fixed `#563 <https://github.com/sdss/marvin/issues/563>`_ - fail retrieving Query datamodels in Python 3.6+.
 - Fixes bug with sasurl not properly being set to api.sdss.org on initial import
 
 Refactored

--- a/python/marvin/utils/datamodel/query/base.py
+++ b/python/marvin/utils/datamodel/query/base.py
@@ -5,8 +5,8 @@
 #
 # @Author: Brian Cherinka
 # @Date:   2017-08-22 22:43:15
-# @Last modified by:   Brian Cherinka
-# @Last modified time: 2017-11-14 11:11:27
+# @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Last modified time: 2018-11-08 12:26:08
 
 from __future__ import absolute_import, division, print_function
 
@@ -22,11 +22,14 @@ import yamlordereddictloader
 from astropy.table import Table
 from fuzzywuzzy import fuzz, process
 from sqlalchemy_utils import get_hybrid_properties
+
 from marvin import config
 from marvin.core.exceptions import MarvinError, MarvinUserWarning
 from marvin.utils.datamodel import DataModelList
 from marvin.utils.datamodel.maskbit import get_maskbits
 from marvin.utils.general.structs import FuzzyList
+
+
 if config.db:
     from marvin.utils.datamodel.query.forms import MarvinForm
 else:
@@ -121,7 +124,8 @@ class QueryDataModel(object):
                 # this deals with all parameters from all releases at once
                 PARAM_CACHE.update(ii.getData())
                 self._check_aliases()
-                for key in PARAM_CACHE.keys():
+
+                for key in list(PARAM_CACHE.keys()):
                     self._keys = PARAM_CACHE[key] if key in PARAM_CACHE else []
                     print('length of keys', len(self._keys))
                     self._remove_query_params()


### PR DESCRIPTION
Fixes #563

This just casts the keys over which we are iterating to a list so that if the dictionary changes we don't get an error. I think this is only a problem with 3.6+. A different issue is why we need to do a remote call for each query data model even if we are only getting a `Maps` but let's deal with that separately.

This pull request:
- [X] Has a title that summarises what is changing.
- [ ] Updates the documentation accordingly.
- [ ] Has unit tests & [code coverage](https://coveralls.io/github/sdss/marvin) is not adversely affected (within reason).
- [ ] Works with Python 2.7 and 3.6 (and ideally with Python 3.7).
- [X] Updates the [CHANGELOG](https://github.com/sdss/marvin/blob/master/CHANGELOG.rst).
- [ ] Removes more lines of code than it adds.
- [ ] If relevant, adds a new entry to the [What's new?](https://github.com/sdss/marvin/blob/master/docs/sphinx/whats-new.rst) page.
