### PR TITLE
Gunzip files temporarily

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Breaking changes
 ^^^^^^^^^^^^^^^^
 - Removed ``Bin`` class. Bin information is now available on a per-quantity basis (:issue:`109`). See :ref:`What's new? <whats-new>` and documentation for details.
 - Syntax on the inputs to the ``Query`` and ``Results`` tools has been changed.
+- ``getSpaxel`` now only loads the quantities from the parent object (that means that, for example, ``Maps.getSpaxel`` only loads ``Maps`` properties by default). Additional quantities can be loaded using `~marvin.tools.spaxel.Spaxel.load`.
+- ``getSpaxel`` accepted arguments have been changed to ``cube``, ``maps``, and ``modelcube``. The formerly accepted arguments (``drp``, ``properties``, ``model(s)``) now raise a deprecation error.
 
 Added
 ^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,7 @@ Changed
 - Replaced inconsistent parameter ``model`` in `~marvin.tools.maps.Maps.getSpaxel`. Use ``models`` instead.
 - MarvinError now accepts an optional `ignore_git` keyword to locally turn off the git addition to the message
 - Using the `return_all` keyword in ``Query`` or `getAll` in ``Results`` now calls the streaming API route instead.
+- When `~marvin.tool.cube.Cube` or `~marvin.tool.modelcube.ModelCube` are instantiated from file, gunzip the file to a temporary location to speed up subsequent access (:issue:`525`).
 
 Fixed
 ^^^^^

--- a/python/marvin/tests/tools/test_spaxel.py
+++ b/python/marvin/tests/tools/test_spaxel.py
@@ -308,7 +308,7 @@ class TestPickling(object):
         cube = Cube(filename=galaxy.cubepath)
         maps = Maps(filename=galaxy.mapspath)
 
-        spaxel = cube.getSpaxel(1, 3, properties=maps, models=False)
+        spaxel = cube.getSpaxel(1, 3, maps=maps, modelcube=False)
 
         file = temp_scratch.join('test_spaxel.mpf')
 
@@ -336,7 +336,7 @@ class TestPickling(object):
         cube = Cube(plateifu=galaxy.plateifu, mode='remote')
         maps = Maps(plateifu=galaxy.plateifu, mode='remote')
         modelcube = ModelCube(plateifu=galaxy.plateifu, mode='remote')
-        spaxel = cube.getSpaxel(1, 3, properties=maps, models=modelcube)
+        spaxel = cube.getSpaxel(1, 3, maps=maps, modelcube=modelcube)
 
         assert spaxel._cube.data_origin == 'api'
         assert spaxel._maps.data_origin == 'api'
@@ -376,7 +376,7 @@ class TestPickling(object):
 
         maps = Maps(filename=galaxy.mapspath)
         modelcube = ModelCube(filename=galaxy.modelpath)
-        spaxel = maps.getSpaxel(25, 15, xyorig='lower', drp=False, models=modelcube)
+        spaxel = maps.getSpaxel(25, 15, xyorig='lower', cube=False, modelcube=modelcube)
 
         file = temp_scratch.join('test_spaxel.mpf')
 
@@ -403,7 +403,7 @@ class TestMaskbit(object):
     @marvin_test_if(mark='skip', galaxy=dict(release=['MPL-4']))
     def test_quality_flags(self, galaxy):
         maps = Maps(plateifu=galaxy.plateifu)
-        sp = maps.getSpaxel(0, 0, models=True)
+        sp = maps.getSpaxel(0, 0, modelcube=True)
         assert len(sp.quality_flags) == 2
 
 
@@ -630,17 +630,20 @@ class TestMapsGetSpaxel(object):
             assert map[yy, xx].ivar == pytest.approx(channel_data['ivar'], abs=1.e-4)
 
     @marvin_test_if(mark='include', galaxy=dict(bintype=['SPX']))
-    def test_model_deprecated(self, galaxy, exporigin):
+    def test_deprecated(self, galaxy, exporigin):
 
         if exporigin != 'db':
             pytest.skip()
 
         maps = Maps(**self._get_maps_kwargs(galaxy, exporigin))
 
-        with pytest.raises(MarvinDeprecationError) as ee:
-            maps.getSpaxel(x=0, y=0, model=True)
+        for old_arg in ['drp', 'properties', 'model', 'models']:
 
-        assert 'the model parameter has been deprecated. Use models.' in str(ee)
+            with pytest.raises(MarvinDeprecationError) as ee:
+                kwargs = {old_arg: True}
+                maps.getSpaxel(x=0, y=0, **kwargs)
+
+            assert 'the {0} parameter has been deprecated.'.format(old_arg) in str(ee)
 
 
 @marvin_test_if_class(mark='skip', galaxy=dict(release=['MPL-4']))
@@ -687,7 +690,7 @@ class TestModelCubeGetSpaxel(object):
         model_cube = ModelCube(plateifu=galaxy.plateifu,
                                bintype=galaxy.bintype, template=galaxy.template,
                                release=galaxy.release, )
-        spaxel = _get_spaxel_helper(model_cube, 1, 2, properties=False, drp=False)
+        spaxel = _get_spaxel_helper(model_cube, 1, 2, maps=False, cube=False)
         self._test_getspaxel(spaxel, galaxy)
         assert isinstance(spaxel.getCube(), Cube)
         assert 'flux' not in spaxel.cube_quantities

--- a/python/marvin/tools/cube.py
+++ b/python/marvin/tools/cube.py
@@ -6,8 +6,8 @@
 # @Filename: cube.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
-# @Last modified by:   Brian Cherinka
-# @Last modified time: 2018-08-12 04:35:22
+# @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Last modified time: 2018-11-08 19:13:31
 
 
 from __future__ import absolute_import, division, print_function
@@ -26,7 +26,8 @@ import marvin.utils.general.general
 from marvin.core.exceptions import MarvinError, MarvinUserWarning
 from marvin.tools.quantities import DataCube, Spectrum
 from marvin.utils.datamodel.drp import datamodel
-from marvin.utils.general import FuzzyDict, get_nsa_data
+from marvin.utils.general import FuzzyDict, get_nsa_data, gunzip
+
 from .core import MarvinToolsClass
 from .mixins import GetApertureMixIn, NSAMixIn
 
@@ -176,7 +177,8 @@ class Cube(MarvinToolsClass, NSAMixIn, GetApertureMixIn):
             assert isinstance(data, fits.HDUList), 'data is not an HDUList object'
         else:
             try:
-                self.data = fits.open(self.filename)
+                with gunzip(self.filename) as gg:
+                    self.data = fits.open(gg.name)
             except (IOError, OSError) as err:
                 raise OSError('filename {0} cannot be found: {1}'.format(self.filename, err))
 
@@ -186,8 +188,7 @@ class Cube(MarvinToolsClass, NSAMixIn, GetApertureMixIn):
         self._check_file(self.data[0].header, self.data, 'Cube')
 
         self._wavelength = self.data['WAVE'].data
-        self._shape = (self.data['FLUX'].header['NAXIS2'],
-                       self.data['FLUX'].header['NAXIS1'])
+        self._shape = (self.header['NAXIS2'], self.header['NAXIS1'])
 
         self._do_file_checks(self)
 

--- a/python/marvin/tools/cube.py
+++ b/python/marvin/tools/cube.py
@@ -584,10 +584,10 @@ class Cube(MarvinToolsClass, NSAMixIn, GetApertureMixIn):
     def getMaps(self, **kwargs):
         """Retrieves the DAP :class:`~marvin.tools.maps.Maps` for this cube.
 
-        If called without additional ``kwargs``, :func:`getMaps` will initilise
-        the :class:`~marvin.tools.maps.Maps` using the ``plateifu`` of this
-        :class:`~marvin.tools.cube.Cube`. Otherwise, the ``kwargs`` will be
-        passed when initialising the :class:`~marvin.tools.maps.Maps`.
+        If called without additional ``kwargs``, :func:`getMaps` will
+        initialise the :class:`~marvin.tools.maps.Maps` using the ``plateifu``
+        of this :class:`~marvin.tools.cube.Cube`. Otherwise, the ``kwargs``
+        will be passed when initialising the :class:`~marvin.tools.maps.Maps`.
 
         """
 
@@ -595,5 +595,5 @@ class Cube(MarvinToolsClass, NSAMixIn, GetApertureMixIn):
             kwargs.update({'plateifu': self.plateifu, 'release': self._release})
 
         maps = marvin.tools.maps.Maps(**kwargs)
-        maps._cube = self
+
         return maps

--- a/python/marvin/tools/cube.py
+++ b/python/marvin/tools/cube.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2018-11-08 19:13:31
+# @Last modified time: 2018-11-14 10:49:33
 
 
 from __future__ import absolute_import, division, print_function
@@ -530,7 +530,7 @@ class Cube(MarvinToolsClass, NSAMixIn, GetApertureMixIn):
         return cube_quantities
 
     def getSpaxel(self, x=None, y=None, ra=None, dec=None,
-                  properties=True, models=False, **kwargs):
+                  maps=False, modelcube=False, **kwargs):
         """Returns the :class:`~marvin.tools.spaxel.Spaxel` matching certain coordinates.
 
         The coordinates of the spaxel to return can be input as ``x, y`` pixels
@@ -553,10 +553,10 @@ class Cube(MarvinToolsClass, NSAMixIn, GetApertureMixIn):
                 lower-left corner. This keyword is ignored if ``ra`` and
                 ``dec`` are defined. ``xyorig`` defaults to
                 ``marvin.config.xyorig.``
-            properties (bool):
+            maps (`~marvin.tools.maps.Maps` or None or bool):
                 If ``True``, the spaxel will be initiated with the DAP
                 properties from the default Maps matching this cube.
-            models (`~marvin.tools.modelcube.ModelCube` or None or bool):
+            modelcube (`~marvin.tools.modelcube.ModelCube` or None or bool):
                 A :class:`~marvin.tools.modelcube.ModelCube` object
                 representing the DAP modelcube entity. If None, the |spaxel|
                 will be returned without model information. Default is False.
@@ -571,10 +571,17 @@ class Cube(MarvinToolsClass, NSAMixIn, GetApertureMixIn):
 
         """
 
+        for old_param in ['properties', 'model', 'models']:
+            if old_param in kwargs:
+                raise marvin.core.exceptions.MarvinDeprecationError(
+                    'the {0} parameter has been deprecated. '
+                    'Use maps or modelcube.'.format(old_param))
+
         return marvin.utils.general.general.getSpaxel(x=x, y=y, ra=ra, dec=dec,
                                                       cube=self,
-                                                      maps=properties,
-                                                      modelcube=models, **kwargs)
+                                                      maps=maps,
+                                                      modelcube=modelcube,
+                                                      **kwargs)
 
     def getRSS(self):
         """Returns the `~marvin.tools.rss.RSS` associated with this Cube."""

--- a/python/marvin/tools/maps.py
+++ b/python/marvin/tools/maps.py
@@ -6,8 +6,8 @@
 # @Filename: maps.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
-# @Last modified by:   Brian Cherinka
-# @Last modified time: 2018-08-23 11:53:04
+# @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Last modified time: 2018-11-14 10:49:45
 
 
 from __future__ import absolute_import, division, print_function
@@ -34,6 +34,7 @@ import marvin.utils.general.general
 from marvin.utils.datamodel.dap import datamodel
 from marvin.utils.datamodel.dap.base import Channel, Property
 from marvin.utils.general import FuzzyDict, turn_off_ion
+
 from .core import MarvinToolsClass
 from .mixins import DAPallMixIn, GetApertureMixIn, NSAMixIn
 from .quantities import AnalysisProperty
@@ -521,7 +522,7 @@ class Maps(MarvinToolsClass, NSAMixIn, DAPallMixIn, GetApertureMixIn):
                                                 template=self.template)
 
     def getSpaxel(self, x=None, y=None, ra=None, dec=None,
-                  drp=True, models=False, model=None, **kwargs):
+                  cube=False, modelcube=False, **kwargs):
         """Returns the :class:`~marvin.tools.spaxel.Spaxel` matching certain coordinates.
 
         The coordinates of the spaxel to return can be input as ``x, y`` pixels
@@ -546,10 +547,10 @@ class Maps(MarvinToolsClass, NSAMixIn, DAPallMixIn, GetApertureMixIn):
                 spatial dimensions of the cube, or ``'lower'`` for the
                 lower-left corner. This keyword is ignored if ``ra`` and
                 ``dec`` are defined.
-            drp (bool):
+            cube (bool):
                 If ``True``, the |spaxel| will be initialised with the
-                corresponding DRP data.
-            models (bool):
+                corresponding DRP cube data.
+            modelcube (bool):
                 If ``True``, the |spaxel| will be initialised with the
                 corresponding `.ModelCube` data.
 
@@ -564,13 +565,15 @@ class Maps(MarvinToolsClass, NSAMixIn, DAPallMixIn, GetApertureMixIn):
 
         """
 
-        if model is not None:
-            raise marvin.core.exceptions.MarvinDeprecationError(
-                'the model parameter has been deprecated. Use models.')
+        for old_param in ['drp', 'model', 'models']:
+            if old_param in kwargs:
+                raise marvin.core.exceptions.MarvinDeprecationError(
+                    'the {0} parameter has been deprecated. '
+                    'Use cube or modelcube.'.format(old_param))
 
         return marvin.utils.general.general.getSpaxel(
             x=x, y=y, ra=ra, dec=dec,
-            cube=drp, maps=self, modelcube=models, **kwargs)
+            cube=cube, maps=self, modelcube=modelcube, **kwargs)
 
     def _match_properties(self, property_name, channel=None, exact=False):
         """Returns the best match for a property_name+channel."""

--- a/python/marvin/tools/modelcube.py
+++ b/python/marvin/tools/modelcube.py
@@ -6,8 +6,8 @@
 # @Filename: modelcube.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
-# @Last modified by:   Brian Cherinka
-# @Last modified time: 2018-08-12 13:35:11
+# @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Last modified time: 2018-11-08 19:00:44
 
 
 from __future__ import absolute_import, division, print_function
@@ -27,7 +27,7 @@ import marvin.utils.general.general
 from marvin.core.exceptions import MarvinError
 from marvin.tools.quantities import DataCube, Map, Spectrum
 from marvin.utils.datamodel.dap import Model, datamodel
-from marvin.utils.general import FuzzyDict
+from marvin.utils.general import FuzzyDict, gunzip
 
 from .core import MarvinToolsClass
 from .mixins import DAPallMixIn, GetApertureMixIn, NSAMixIn
@@ -178,7 +178,8 @@ class ModelCube(MarvinToolsClass, NSAMixIn, DAPallMixIn, GetApertureMixIn):
             assert isinstance(self.data, fits.HDUList), 'data is not an HDUList object'
         else:
             try:
-                self.data = fits.open(self.filename)
+                with gunzip(self.filename) as gg:
+                    self.data = fits.open(gg.name)
             except IOError as err:
                 raise IOError('filename {0} cannot be found: {1}'.format(self.filename, err))
 

--- a/python/marvin/tools/modelcube.py
+++ b/python/marvin/tools/modelcube.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2018-11-08 19:00:44
+# @Last modified time: 2018-11-14 11:43:13
 
 
 from __future__ import absolute_import, division, print_function
@@ -304,7 +304,7 @@ class ModelCube(MarvinToolsClass, NSAMixIn, DAPallMixIn, GetApertureMixIn):
         self.mangaid = str(self.header['MANGAID'].strip())
 
     def getSpaxel(self, x=None, y=None, ra=None, dec=None,
-                  drp=True, properties=True, **kwargs):
+                  cube=False, maps=False, **kwargs):
         """Returns the :class:`~marvin.tools.spaxel.Spaxel` matching certain coordinates.
 
         The coordinates of the spaxel to return can be input as ``x, y`` pixels
@@ -331,12 +331,12 @@ class ModelCube(MarvinToolsClass, NSAMixIn, DAPallMixIn, GetApertureMixIn):
                 spatial dimensions of the cube, or ``'lower'`` for the
                 lower-left corner. This keyword is ignored if ``ra`` and
                 ``dec`` are defined.
-            drpa (bool):
+            cube (bool):
                 If ``True``, the |spaxel| will be initialised with the
-                corresponding DRP data.
-            properties (bool):
+                corresponding DRP cube data.
+            maps (bool):
                 If ``True``, the |spaxel| will be initialised with the
-                corresponding DAP properties for this spaxel.
+                corresponding DAP Maps properties for this spaxel.
 
         Returns:
             spaxels (list):
@@ -348,9 +348,15 @@ class ModelCube(MarvinToolsClass, NSAMixIn, DAPallMixIn, GetApertureMixIn):
 
         """
 
+        for old_param in ['drp', 'properties']:
+            if old_param in kwargs:
+                raise marvin.core.exceptions.MarvinDeprecationError(
+                    'the {0} parameter has been deprecated. '
+                    'Use cube or maps.'.format(old_param))
+
         return marvin.utils.general.general.getSpaxel(
             x=x, y=y, ra=ra, dec=dec,
-            cube=drp, maps=properties, modelcube=self, **kwargs)
+            cube=cube, maps=maps, modelcube=self, **kwargs)
 
     def _get_extension_data(self, name, ext=None):
         """Returns the data from an extension."""

--- a/python/marvin/tools/spaxel.py
+++ b/python/marvin/tools/spaxel.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2018-08-12 13:27:57
+# @Last modified time: 2018-11-08 18:00:34
 
 
 from __future__ import absolute_import, division, print_function
@@ -17,7 +17,6 @@ import itertools
 import warnings
 
 import numpy as np
-import six
 
 import marvin
 import marvin.core.exceptions

--- a/python/marvin/utils/general/structs.py
+++ b/python/marvin/utils/general/structs.py
@@ -7,7 +7,7 @@
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
-# @Last modified time: 2018-11-08 18:58:09
+# @Last modified time: 2018-11-08 19:01:24
 
 
 from __future__ import absolute_import, division, print_function
@@ -292,6 +292,7 @@ def string_folding_wrapper(results, keys=None):
 
 @contextmanager
 def gunzip(filename):
+    """Context manager than gunzips a file temporarily."""
 
     temp_file = tempfile.NamedTemporaryFile(mode='wb')
     temp_file.file.write(gzip.GzipFile(filename).read())

--- a/python/marvin/utils/general/structs.py
+++ b/python/marvin/utils/general/structs.py
@@ -6,13 +6,16 @@
 # @Filename: structs.py
 # @License: BSD 3-clause (http://www.opensource.org/licenses/BSD-3-Clause)
 #
-# @Last modified by:   Brian Cherinka
-# @Last modified time: 2018-08-11 20:20:17
+# @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
+# @Last modified time: 2018-11-08 18:58:09
 
 
 from __future__ import absolute_import, division, print_function
 
+import gzip
+import tempfile
 from collections import OrderedDict
+from contextlib import contextmanager
 
 import six
 from fuzzywuzzy import fuzz as fuzz_fuzz
@@ -20,7 +23,7 @@ from fuzzywuzzy import process as fuzz_proc
 
 
 __ALL__ = ['FuzzyDict', 'Dotable', 'DotableCaseInsensitive', 'get_best_fuzzy',
-           'FuzzyList', 'string_folding_wrapper']
+           'FuzzyList', 'string_folding_wrapper', 'gunzip']
 
 
 class Dotable(dict):
@@ -285,3 +288,15 @@ def string_folding_wrapper(results, keys=None):
             folder.fold_string(row.__getattribute__(key))
             for key in keys
         )
+
+
+@contextmanager
+def gunzip(filename):
+
+    temp_file = tempfile.NamedTemporaryFile(mode='wb')
+    temp_file.file.write(gzip.GzipFile(filename).read())
+
+    try:
+        yield temp_file
+    finally:
+        temp_file.close()

--- a/python/marvin/web/controllers/galaxy.py
+++ b/python/marvin/web/controllers/galaxy.py
@@ -10,25 +10,29 @@ Revision History:
     Last Modified On: 2016-04-08 14:31:34 by Brian
 
 '''
-from __future__ import print_function
-from __future__ import division
-from flask import Blueprint, render_template, session as current_session, request, jsonify
-from flask_classful import route
-import marvin
-from marvin.utils.general.general import (convertImgCoords, parseIdentifier, getDefaultMapPath,
-                                          getDapRedux, _db_row_to_dict, target_status)
+from __future__ import division, print_function
+
+import os
+
+import numpy as np
 from brain.utils.general.general import convertIvarToErr
+from flask import Blueprint, jsonify, render_template, request
+from flask import session as current_session
+from flask_classful import route
+
+import marvin
+from marvin.api.base import arg_validate as av
+from marvin.core import marvin_pickle
+from marvin.core.caching_query import FromCache
 from marvin.core.exceptions import MarvinError
 from marvin.tools.cube import Cube
 from marvin.utils.datamodel.dap import datamodel
+from marvin.utils.general.general import (_db_row_to_dict, convertImgCoords, getDapRedux,
+                                          getDefaultMapPath, parseIdentifier, target_status)
 from marvin.utils.general.maskbit import Maskbit
 from marvin.web.controllers import BaseWebView
 from marvin.web.extensions import cache
-from marvin.api.base import arg_validate as av
-from marvin.core.caching_query import FromCache
-from marvin.core import marvin_pickle
-import os
-import numpy as np
+
 
 try:
     from sdss_access.path import Path
@@ -45,8 +49,8 @@ def getWebSpectrum(cube, x, y, xyorig=None, byradec=False):
     has_models = cube.data.has_modelspaxels(name=default_bintype) if hasattr(cube.data, 'has_modelspaxels') else False
 
     # set the spaxel kwargs
-    kwargs = {'xyorig': xyorig, 'properties': False}
-    kwargs['models'] = has_models
+    kwargs = {'xyorig': xyorig, 'maps': False}
+    kwargs['modelcube'] = has_models
     if byradec:
         kwargs.update({'ra': x, 'dec': y})
     else:


### PR DESCRIPTION
Fixes #525

Introduces a `gunzip` context manager. When a `Cube` or `ModelCube` is instantiated from a file, it gunzips the whole file to a temporary location from where it's read. The temporary file is destroyed when not needed anymore. This significantly speeds up subsequent accesses to the data stored in the file. The only downside is that the initial creation of the object takes a bit longer, especially for files of large IFUs.

This pull request:
- [X] Has a title that summarises what is changing.
- [ ] Updates the documentation accordingly.
- [X] Has unit tests & [code coverage](https://coveralls.io/github/sdss/marvin) is not adversely affected (within reason).
- [X] Works with Python 2.7 and 3.6 (and ideally with Python 3.7).
- [X] Updates the [CHANGELOG](https://github.com/sdss/marvin/blob/master/CHANGELOG.rst).
- [ ] Removes more lines of code than it adds.
- [ ] If relevant, adds a new entry to the [What's new?](https://github.com/sdss/marvin/blob/master/docs/sphinx/whats-new.rst) page.
