### PR TITLE
Turns off Sentry for final release

### DIFF
--- a/python/marvin/__init__.py
+++ b/python/marvin/__init__.py
@@ -107,7 +107,7 @@ class MarvinConfig(object):
 
         self.vermode = None
         self.download = False
-        self.use_sentry = True
+        self.use_sentry = False
         self.add_github_message = True
         self._allowed_releases = {}
 

--- a/python/marvin/data/marvin.yml
+++ b/python/marvin/data/marvin.yml
@@ -8,7 +8,7 @@ check_access: False
 use_token: ''
 
 # use the Sentry error logging
-use_sentry: True
+use_sentry: False
 
 # add a message to submit a new Github Issue on all MarvinErrors
 add_github_message: True

--- a/python/marvin/web/settings.py
+++ b/python/marvin/web/settings.py
@@ -88,7 +88,7 @@ class ProdConfig(Config):
     SQLALCHEMY_DATABASE_URI = 'postgresql://localhost/example'
     DEBUG_TB_ENABLED = False  # Disable Debug toolbar
     USE_X_SENDFILE = True
-    USE_SENTRY = True
+    USE_SENTRY = False
     SENTRY_DSN = os.environ.get('SENTRY_DSN', None)
     PERMANENT_SESSION_LIFETIME = datetime.timedelta(3600)
     JWT_ACCESS_TOKEN_EXPIRES = datetime.timedelta(300)
@@ -118,7 +118,7 @@ class DockerConfig(Config):
     SQLALCHEMY_DATABASE_URI = 'postgresql://localhost/example'
     DEBUG_TB_ENABLED = False  # Disable Debug toolbar
     USE_X_SENDFILE = True
-    USE_SENTRY = True
+    USE_SENTRY = False
     SENTRY_DSN = os.environ.get('SENTRY_DSN', None)
     PERMANENT_SESSION_LIFETIME = datetime.timedelta(3600)
     JWT_ACCESS_TOKEN_EXPIRES = datetime.timedelta(300)


### PR DESCRIPTION
This PR turns off Sentry inside marvin.  I rarely check this and don't have time to maintain it.  The Sentry SDK needs to be updated in Marvin anyways.  Leaving the code in place just in case we ever want to re-enable it.   To be merged after #747 .
