### PR TITLE
Bug fix in Marvin Tools class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Marvin's Change Log
 ===================
 
+[2.6.2] - unreleased
+--------------------
+- Fixing bug in core Marvin Tools `close` method, for use as contextmanager
+
 [2.6.1] - 2021/11/18
 --------------------
 - Issue :issue:`680` - Basic context manager functionality for ``marvin.tools.core.MarvinToolsClass``, and relevant documentation for ``Cube`` and ``Maps``. Users can automate closing file handlers when in ``file`` mode, by using ``with`` syntax, alleviating some issues with looping through lists of galaxies.

--- a/python/marvin/tools/core.py
+++ b/python/marvin/tools/core.py
@@ -237,15 +237,12 @@ class MarvinToolsClass(MMAMixIn, CacheMixIn):
         return source_is_file and data_from_hdulist
 
     def close(self):
-        if self.source_is_fits_hdulist:
+        if self.source_is_fits_hdulist_file:
             try:
                 self.data.close()
             except Exception as ee:
                 warnings.warn('failed to close FITS instance: {0}'.format(ee), MarvinUserWarning)
-        else:
-            warnings.warn(
-                'data-origin {0} ({1}) not closeable'.format(self.data_origin, self.data.__class__),
-                MarvinUserWarning)
+
 
     def __del__(self):
         """Destructor for closing FITS files."""


### PR DESCRIPTION
This fixes a bug in the MarvinTools core `close` method, when objects used as contextmanager.
