### PR TITLE
More fixes for VACs 

### DIFF
--- a/python/marvin/contrib/vacs/base.py
+++ b/python/marvin/contrib/vacs/base.py
@@ -89,6 +89,7 @@ class VACMixIn(object, six.with_metaclass(abc.ABCMeta)):
     """
     # Set this is True on your VAC to exclude it from Marvin
     _hidden = False
+    _hidden_for = None
 
     # The name and description of the VAC.
     name = None
@@ -164,10 +165,6 @@ class VACMixIn(object, six.with_metaclass(abc.ABCMeta)):
         vac_container = VACContainer()
 
         for subvac in VACMixIn.__subclasses__():
-            # check if VAC is hidden
-            if subvac._hidden:
-                continue
-
             # Excludes VACs from showing up in Plate
             if issubclass(parent_object.__class__, marvin.tools.plate.Plate):
                 continue
@@ -175,6 +172,11 @@ class VACMixIn(object, six.with_metaclass(abc.ABCMeta)):
             # Only shows VACs if in the include list.
             if (hasattr(subvac, 'include') and subvac.include is not None and
                     not issubclass(parent_object.__class__, subvac.include)):
+                continue
+
+            # check if VAC is hidden
+            if subvac._hidden and (not subvac._hidden_for or 
+                                   (subvac._hidden_for == parent_object._release)):
                 continue
 
             # We need to set sv=subvac in the lambda function to prevent

--- a/python/marvin/contrib/vacs/galaxyzoo.py
+++ b/python/marvin/contrib/vacs/galaxyzoo.py
@@ -73,7 +73,7 @@ class GZVAC(VACMixIn):
             self.data_container = dict(zip(files, self.summary_file))
         else: 
             # for other releases prior to DR17, simply do based on release as before
-            self.path_params.append({"ver": self.version[release]})
+            self.path_params.append({"ver": self.version[release], "file": "gz"})
             self.summary_file.append(self.get_path("mangagalaxyzoo", path_params=self.path_params[0]))
 
     # Required method

--- a/python/marvin/contrib/vacs/visual_morph.py
+++ b/python/marvin/contrib/vacs/visual_morph.py
@@ -33,6 +33,9 @@ class VMORPHOVAC(VACMixIn):
     Authors: J. Antonio Vazquez-Mata and Hector Hernandez-Toledo
 
     """
+    #  hidden from DR17 until future notice
+    _hidden = True
+    _hidden_for = 'DR17'
 
     # Required parameters
     name = 'visual_morphology'
@@ -174,17 +177,20 @@ class VizMorphTarget(VACTarget):
             A matplotlib axis object
         '''
         
-        print('NOTE: For DR16, must specify either survey: sdss or desi. For DR17 must write: mos')
+        #print('NOTE: For DR16, must specify either survey: sdss or desi. For DR17 must write: mos')
 
         if survey == 'sdss':
             impath = self._sdss_img
             fsize = (15,5)
-        if survey == 'desi':
+        elif survey == 'desi':
             impath = self._desi_img
             fsize = (10,5)
-        if survey == 'mos':
+        elif survey == 'mos':
             impath = self._mos_img
             fsize = (20,5)
+        else:
+            raise ValueError('survey must be either "sdss" or "desi" for DR16, or "mos" for DR17')
+
         imdata = mpimg.imread(impath)
         fig, ax = plt.subplots(figsize = fsize)
         ax.imshow(imdata)

--- a/python/marvin/web/controllers/galaxy.py
+++ b/python/marvin/web/controllers/galaxy.py
@@ -287,34 +287,40 @@ def remove_nans(datadict):
     return datadict
 
 
-def create_vacdata(mangaid: str) -> dict:
+def create_vacdata(mangaid: str, release: str = None) -> dict:
     """ create a dictionary for VAC data for web display
 
     Parameters
     ----------
     mangaid : str
         The target mangaid 
+    release : str
+        The data release to use
 
     Returns
     -------
     dict
         A dictionary of VAC information
     """
+    # hack to get vacs to switch based on release in the web
+    # TODO - improve this
+    release = release or marvin.config.release
+    marvin.config.setRelease(release)
     from marvin.tools.vacs import VACs
     v = VACs()
-    dd = v.check_target(mangaid)
+    #dd = v.check_target(mangaid)
     vacdata=[]
     for i in v.list_vacs():
         if isinstance(v[i], dict):
             for k, j in v[i].items():
                 link = j._rsync.url('', full=j._path)
                 vacdata.append({'name': f'<a target="_blank" href="{j.url}">{j.display_name}: {k}</a>', 
-                                'data': dd[i][k], 'py': f'cube.vacs.{j.name}[{k}]', 
+                                'py': f'cube.vacs.{j.name}[{k}]', #'data': dd[i][k], 
                                 'link': f'<a href="{link}">link</a>'})
         else:
             link = v[i]._rsync.url('', full=v[i]._path)
             vacdata.append({'name': f'<a target="_blank" href="{v[i].url}">{v[i].display_name}</a>',
-                            'data': dd[i], 'py': f'cube.vacs.{v[i].name}', 
+                            'py': f'cube.vacs.{v[i].name}', #'data': dd[i], 
                             'link': f'<a href="{link}">link</a>'})
     return vacdata        
 
@@ -420,7 +426,7 @@ class Galaxy(BaseWebView):
                 daplist = [p.full(web=True) for p in dm.properties]
                 dapdefaults = dm.get_default_mapset()
                 self.galaxy['cube'] = cube
-                self.galaxy['vacdata'] = create_vacdata(cube.mangaid)             
+                self.galaxy['vacdata'] = create_vacdata(cube.mangaid, release=self._release)             
                 self.galaxy['toggleon'] = current_session.get('toggleon', 'false')
                 self.galaxy['cubehdr'] = cube.header
                 self.galaxy['quality'] = ('DRP3QUAL', cube.quality_flag.mask, cube.quality_flag.labels)

--- a/python/marvin/web/templates/galaxy.html
+++ b/python/marvin/web/templates/galaxy.html
@@ -112,7 +112,7 @@
                             </button>
 
                               <div class="modal fade" id="vacTable" tabindex="-1" role="dialog" aria-labelledby="vacLabel" aria-hidden="true">
-                                <div class="modal-dialog modal-lg">
+                                <div class="modal-dialog">
                                   <div class="modal-content">
                                     <div class="modal-header">
                                       <button type="button" class="close" data-dismiss="modal" aria-label="Close">
@@ -126,14 +126,14 @@
                                         <thead>
                                           <tr>
                                             <th data-field="name">Name</th>
-                                            <th data-field="data">Has Target Data</th>
+                                            {# <th data-field="data">Has Target Data</th> #}
                                             <th data-field="py">Access in Python</th>
                                             <th data-field="link">Download</th>
                                           </tr>
                                         </thead>
                                         <tbody>
                                           {% for vc in vacdata %}
-                                          <tr><td>{{vc.name|safe}}</td><td>{{vc.data}}</td><td>{{vc.py}}</td><td>{{vc.link|safe}}</td></tr>
+                                          <tr><td>{{vc.name|safe}}</td><td>{{vc.py}}</td><td>{{vc.link|safe}}</td></tr>
                                           {% endfor %}
                                         </tbody>
                                       </table>
@@ -142,12 +142,12 @@
                                       <div class='row'>
                                         <div class='col-md-6'>
                                           <div class='infopop text-left' id='vactarg'>
-                                          {{infopopup('Access this target VAC in Python', 'Marvin VACs - start iPython', vactargstr, 'vactarg', 'info', place='right')}}
+                                          {{infopopup('Access this target VAC in Python', 'Marvin VACs - start iPython', vactargstr, 'vactarg', 'info', place='left')}}
                                           </div>
                                         </div>
                                         <div class='col-md-6'>
                                           <div class='infopop text-right' id='vactool'>
-                                          {{infopopup('Access all VACs in Python', 'Marvin VACs - start iPython', vactoolstr, 'vactool', 'info', place='left')}}
+                                          {{infopopup('Access all VACs in Python', 'Marvin VACs - start iPython', vactoolstr, 'vactool', 'info', place='right')}}
                                           </div>
                                         </div>
                                       </div>

--- a/python/marvin/web/uwsgi_conf_files/base.ini
+++ b/python/marvin/web/uwsgi_conf_files/base.ini
@@ -37,9 +37,9 @@ enable-threads = true
 lazy-apps = true
 
 sharedarea = 4
-limit-as = 8192
-reload-on-as = 4096
-reload-on-rss = 4096
+limit-as = 16384
+reload-on-as = 8192
+reload-on-rss = 8192
 buffer-size = 65535
 
 memory-report = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ install_requires =
     webargs>=1.5.2,<6.0
     Flask-JWT-Extended>=3.8.1,<4.0
     # database
-    dogpile.cache>=0.6.2,<2.0
+    dogpile.cache>=0.6.2,<1.1
 
 scripts =
     bin/run_marvin

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,8 +42,8 @@ include_package_data = True
 install_requires =
     # sdss reqs
 	sdsstools>=0.4,<1.0
-	sdss-tree>=3.0.7,<4.0
-	sdss-access>=1.0,<2.0
+	sdss-tree>=3.1.0,<4.0
+	sdss-access>=2.0,<3.0
     marvin-brain>=0.2,<1.0
     marvin-sqlalchemy-boolean-search>=0.2,<1.0
     marvin-wtforms-alchemy>=0.16.9,<1.0


### PR DESCRIPTION
This PR hides the Visual Morphology VAC from Marvin for DR17.   Additionally, it adds the ability to use the `VACs.check_target` or an individual VAC `has_target` methods in a "low-memory" mode.  In this mode, it accesses the individual FITS data extension as a context manager and deletes the HDU from memory immediately afterwards.  This is useful when needing to open a large VAC file in a low-memory environment, e.g. by a web server. 

Since I'm not quite comfortable with the IO involved in opening ~6 VAC files for every hit of the galaxy web page, I'm hiding the web display of the VAC "is target available" check until a better solution can be implemented.

It also updates the pinned version of some of Marvin's dependencies. 

It also bumps the memory of the web application.  