### PR TITLE
Fixes bug in bpt method

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.6.2dev
+current_version = 2.7.0dev
 commit = True
 tag = False
 tag_name = {new_version}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Marvin's Change Log
 - Improves performance of web query table
 - Adds export table button option to web query table
 - Improves web pages with various tooltips and other small improvements 
+- Fixes bug in `get_bpt` method with `add_all` kwargs to `ImageGrid` for `matplotlib>3.5`
 
 [2.6.1] - 2021/11/18
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ Marvin's Change Log
 - Added new explore page in the web to upload a target list and display DAP maps
 - Adds basic VAC availablity to galaxy web page
 - Updates the Marvin Query `Results.toJson` method to return a more flexible JSON format
+- Improves performance of web query table
+- Adds export table button option to web query table
+- Improves web pages with various tooltips and other small improvements 
 
 [2.6.1] - 2021/11/18
 --------------------

--- a/docs/sphinx/web.rst
+++ b/docs/sphinx/web.rst
@@ -89,6 +89,12 @@ galaxies in the results.  This page displays up to 16 galaxies at a time, with t
 image linking to the individual galaxy page.  There are pagination buttons to help you cycle through 
 your pages.
 
+**Export Data**:
+
+After a search, the **Export** button will export the table of results to either a CSV or 
+JSON file.  The entire set of results, and columns, will be downloaded regardless of the content
+displayed in the table.
+
 
 .. _web-plate:
 

--- a/docs/sphinx/whats-new.rst
+++ b/docs/sphinx/whats-new.rst
@@ -27,6 +27,8 @@ This section summarises the most important new features a bugfixes in Marvin. Fo
  - conversion to JSON now uses `.pandas.DataFrame.to_json` as default internal mechanism
  - the `toJson` method by default now returns an orientation of a list of records
  
+- Adds "Export Data" button to the web query page
+- Improves performance of data table in the web query page
 
 2.6.1 (November 2021)
 ------------------

--- a/python/marvin/utils/dap/bpt.py
+++ b/python/marvin/utils/dap/bpt.py
@@ -10,8 +10,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+from packaging.version import parse
 import warnings
 
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -70,13 +72,13 @@ def _get_kewley06_axes(use_oi=True):
     plt.subplots_adjust(top=0.99, bottom=0.08, hspace=0.01)
 
     # The axes for the three classification plots
+    imgrid_kwargs = {'add_all': True} if parse(matplotlib.__version__) < parse('3.5.0') else {}
     grid_bpt = ImageGrid(fig, 211,
                          nrows_ncols=(1, 3) if use_oi else (1, 2),
                          direction='row',
                          axes_pad=0.1,
-                         add_all=True,
                          label_mode='L',
-                         share_all=False)
+                         share_all=False, **imgrid_kwargs)
 
     # The axes for the galaxy display
     gal_bpt = ImageGrid(fig, 212, nrows_ncols=(1, 1))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = sdss-marvin
-version = 2.6.2dev
+version = 2.7.0dev
 author = The Marvin Developers
 author_email = havok2063@hotmail.com
 description = Toolsuite for dealing with the MaNGA dataset


### PR DESCRIPTION
This PR fixes a bug in the `get_bpt` method for `matplotlib>3.5`, where the `add_all` kwarg was removed from `ImageGrid` class.
