### PR TITLE
Removes old MPLs from the Query datamodel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Marvin's Change Log
 ===================
 
+[2.7.1] - 2021/12/05
+--------------------
+- Bug fix in Query datamodel.  Removed older MPLs from the datamodel as they are no longer in the database.
+
 [2.7.0] - 2021/12/05
 --------------------
 - Adds support for DR17, aliases to MPL-11

--- a/docs/sphinx/whats-new.rst
+++ b/docs/sphinx/whats-new.rst
@@ -31,6 +31,10 @@ This section summarises the most important new features a bugfixes in Marvin. Fo
 - Adds "Export Data" button to the web query page
 - Improves performance of data table in the web query page
 - Removes web and API support for MPLs 8-10.  These MPLs are still accessible via local file-based mode in Marvin.
+- ..note:: 
+
+  The SDSS rsync file server has recently been upgraded, and modified.  This change requires updates two of marvin's dependencies
+  to continue downloading files.  This version of Marvin depends on `tree==3.1.1` and `sdss-access=2.0.0`.  
 
 2.6.1 (November 2021)
 ---------------------

--- a/python/marvin/utils/datamodel/query/MPL.py
+++ b/python/marvin/utils/datamodel/query/MPL.py
@@ -96,3 +96,8 @@ MPL10 = QueryDataModel(release='MPL-10', groups=groups(),
 
 MPL11 = QueryDataModel(release='MPL-11', groups=groups(),
                        aliases=['DR17', 'MPL11', 'v3_1_1', '3.1.0'], exclude=EX6, dapdm=datamodel['MPL-11'])
+
+# DR17
+
+DR17 = QueryDataModel(release='DR17', groups=groups(),
+                       aliases=['DR17', 'MPL11', 'v3_1_1', '3.1.0'], exclude=EX6, dapdm=datamodel['DR17'])

--- a/python/marvin/utils/datamodel/query/__init__.py
+++ b/python/marvin/utils/datamodel/query/__init__.py
@@ -11,9 +11,10 @@
 from __future__ import print_function, division, absolute_import
 
 from .base import QueryDataModelList
-from .MPL import MPL4, MPL5, MPL6, MPL7, DR15, MPL8, DR16, MPL9, MPL10, MPL11
+from .MPL import MPL7, DR15, DR16, MPL11, DR17
 
-mpllist = [MPL4, MPL5, MPL6, MPL7, DR15, MPL8, DR16, MPL9, MPL10, MPL11]
+#mpllist = [MPL4, MPL5, MPL6, MPL7, DR15, MPL8, DR16, MPL9, MPL10, MPL11]
+mpllist = [MPL7, DR15, DR16, MPL11, DR17]
 
 # Defines the list of datamodels.
 datamodel = QueryDataModelList(mpllist)

--- a/python/marvin/utils/datamodel/query/base.py
+++ b/python/marvin/utils/datamodel/query/base.py
@@ -46,11 +46,11 @@ PARAM_CACHE = {}
 
 def get_allowed_releases():
     ''' get the supported API / web MaNGA releases '''
-    min_release = getattr(config, '_min_web_release', None)
+    web_releases = getattr(config, '_web_releases', None)
     public = config.access == 'public' or os.environ.get(
         'PUBLIC_SERVER', None) is True
     allowed_releases = config.get_allowed_releases(
-        public=public, min_release=min_release)
+        public=public, web_releases=web_releases)
     return allowed_releases
 
 


### PR DESCRIPTION
This removes MPLs 4-6, and 8-10 from the Query datamodel, and fixes the "allowed releases" the Query tool can see, to prevent the following error. 
```
[WARNING]: Could not remotely retrieve full set of parameters. Requests Http Status Error: 409 Client Error: CONFLICT for url: https://sas.sdss.org/marvin/api/query/getparamslist/ (MarvinUserWarning)
```
This warning occurs when marvin makes a request from the server for the allowed query parameters for a release that no longer exists in the database.  