### PR TITLE
Pinning some deps for

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Marvin's Change Log
 ===================
 
+[2.7.4] - 2022/07/27
+--------------------
+- Last tag to support python versions >2.7 up to <3.8
+- Pinning `marvin_brain` and `marvin_wtforms_alchemy` dependencies
+- Additional docs updates
+
 [2.7.3] - 2022/07/12
 --------------------
 - Small tweaks to documentation links and tutorial exercise notebooks

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,20 +41,20 @@ package_dir =
 include_package_data = True
 install_requires =
     # sdss reqs
-	sdsstools>=0.4,<1.0
-	sdss-tree>=3.1.0,<4.0
-	sdss-access>=2.0,<3.0
-    marvin-brain>=0.2,<1.0
-    marvin-sqlalchemy-boolean-search>=0.2,<1.0
-    marvin-wtforms-alchemy>=0.16.9,<1.0
+	sdsstools>=0.4
+	sdss-tree>=3.1.0
+	sdss-access>=2.0
+    marvin-brain>=0.2,<0.3
+    marvin-sqlalchemy-boolean-search>=0.2
+    marvin-wtforms-alchemy>=0.16.9,<0.18.0
     # all else
     # utility
 	astropy>=3.3,<5.0
-    fuzzywuzzy>=0.15.0,<1.0
-    python-Levenshtein>=0.12.0,<1.0
+    fuzzywuzzy>=0.15.0
+    python-Levenshtein>=0.12.0
     raven>=5.32.0,<7.0
     packaging>=20.1,<21.0
-    yamlordereddictloader>=0.2.2,<1.0
+    yamlordereddictloader>=0.2.2
     markupsafe<2.1
     # numerical
     scipy>=0.18.1,<2.0


### PR DESCRIPTION
This PR pins `marvin_brain` and `marvin_wtforms_alchemy` for last release to support python versions >2.7, <3.7.
