### PR TITLE
Relax deps and bump min python to >3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,19 +7,33 @@ on: [push, pull_request]
 
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow_failure }}
 
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8, 3.9]
+        allow_failure: [false]
+        os: [ubuntu-latest]
+        include:
+          - python: "3.10"
+            os: ubuntu-latest
+            allow_failure: true
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]
+
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Marvin's Change Log
 ===================
 
+[2.8.0] - unreleased
+--------------------
+- Drop support for py <3.7.  Min. version is py3.8.
+
 [2.7.4] - 2022/07/27
 --------------------
 - Last tag to support python versions >2.7 up to <3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ classifiers =
 
 [options]
 zip_safe = False
-python_requires = >=2.7
+python_requires = >=3.8
 packages = find:
 package_dir =
 	= python
@@ -44,12 +44,12 @@ install_requires =
 	sdsstools>=0.4
 	sdss-tree>=3.1.0
 	sdss-access>=2.0
-    marvin-brain>=0.2,<0.3
+    marvin-brain>=0.3
     marvin-sqlalchemy-boolean-search>=0.2
-    marvin-wtforms-alchemy>=0.16.9,<0.18.0
+    marvin-wtforms-alchemy>=0.18.0
     # all else
     # utility
-	astropy>=3.3,<5.0
+	astropy>=5.1
     fuzzywuzzy>=0.15.0
     python-Levenshtein>=0.12.0
     raven>=5.32.0,<7.0
@@ -57,10 +57,10 @@ install_requires =
     yamlordereddictloader>=0.2.2
     markupsafe<2.1
     # numerical
-    scipy>=0.18.1,<2.0
+    scipy>=0.18.1
     # plotting
-    pandas>=0.18.1,<2.0
-    matplotlib>=1.5.3,<4.0
+    pandas>=1.0
+    matplotlib>=1.5.3
     # api / web
     webargs>=1.5.2,<6.0
     Flask-JWT-Extended>=3.8.1,<4.0
@@ -86,71 +86,71 @@ extra=
 
 dev =
 	%(docs)s # This forces the docs extras to install (http://bit.ly/2Qz7fzb)
-	ipython>=7.9.0,<8.0
-	matplotlib>=3.1.1,<4.0
-	flake8>=3.7.9,<5.0
-	doc8>=0.8.0,<1.0
-	pytest>=5.2.2,<7.0
-	pytest-cov>=2.8.1,<4.0
-	pytest-sugar>=0.9.4,<1.0
-	pytest-remotedata>=0.3.2,<1.0
-    pytest-flask>=0.10.0,<2.0
-    pytest-xdist>=1.18.1,<3.0
-    pytest-timeout>=1.2.0,<3.0
-	isort>=4.3.21,<6.0
-    coveralls>=1.1,<4.0
-	codecov>=2.0.15,<3.0
-	coverage[toml]>=5.0,<7.0
-	ipdb>=0.12.3,<1.0
+	ipython>=7.9.0
+	matplotlib>=3.1.1
+	flake8>=3.7.9
+	doc8>=0.8.0
+	pytest>=5.2.2
+	pytest-cov>=2.8.1
+	pytest-sugar>=0.9.4
+	pytest-remotedata>=0.3.2
+    pytest-flask>=0.10.0
+    pytest-xdist>=1.18.1
+    pytest-timeout>=1.2.0
+	isort>=4.3.21
+    coveralls>=1.1
+	codecov>=2.0.15
+	coverage[toml]>=5.0
+	ipdb>=0.12.3
 	# The following are needed because sdsstools[dev] as an extra not always
 	# gets installed. See https://github.com/pypa/pip/issues/4957.
-	invoke>=1.3.0,<2.0
-	twine>=3.1.1,<4.0
-	wheel>=0.33.6,<1.0
+	invoke>=1.3.0
+	twine>=3.1.1
+	wheel>=0.33.6
     # other dev depends - e.g. web tests
     #uwsgi>=2.0.15  # install with "conda install -c conda-forge uwsgi" instead
     psycopg2>=2.6.2,<3.0
-    selenium>=3.3.1,<5.0
-    page_objects>=1.1.0,<2.0
-    decorator>=4.1.2,<6.0
-    pympler>=0.5,<1.0
-    mpl-scatter-density>=0.4,<1.0
-    msgpack>=0.5.4,<1.0
-    msgpack-numpy>=0.4.2,<1.0
-    Flask-Testing>=0.6.1,<1.0
+    selenium>=3.3.1
+    page_objects>=1.1.0
+    decorator>=4.1.2
+    pympler>=0.5
+    mpl-scatter-density>=0.4
+    msgpack>=0.5.4
+    msgpack-numpy>=0.4.2
+    Flask-Testing>=0.6.1
 docs =
-	Sphinx>=2.1.0,<4.0
-	sphinx_bootstrap_theme>=0.4.12,<1.0
-    sphinxcontrib-httpdomain>=1.5.0,<2.0
-    sphinx_issues>=1.0.0,<2.0
-    sphinx-rtd-theme>=0.4.2,<2.0
-    nbsphinx>=0.3.5,<1.0
+	Sphinx>=3.1.0,<4.0
+	sphinx_bootstrap_theme>=0.4.12
+    sphinxcontrib-httpdomain>=1.5.0
+    sphinx_issues>=1.0.0
+    sphinx-rtd-theme>=0.4.2
+    nbsphinx>=0.3.5
     # added for rtd issues
-    photutils>=0.7,<2.0
-    mpl-scatter-density>=0.4,<1.0
-    jupyter_client>=5.2.3,<8.0
-    ipykernel>5.0,<7.0
+    photutils>=0.7
+    mpl-scatter-density>=0.4
+    jupyter_client>=5.2.3
+    ipykernel>5.0
 web=
-    blinker>=1.4,<2.0
-    Flask-JSGlue>=0.3,<1.0
-    Flask-FeatureFlags>=0.6,<1.0
-    Flask-Compress>=1.4,<2.0
-    Flask-Limiter>=0.9.4,<2.0
-    flask-profiler>=1.0.1,<2.0
-    Flask-Caching>=1.4.0,<2.0
-    Flask-Login>=0.4.1,<1.0
-    Flask-Cors>=3.0.8,<4.0
-    Flask-Session>=0.3.1,<1.0
-    redis>=3.3,<4.0
+    blinker>=1.4
+    Flask-JSGlue>=0.3
+    Flask-FeatureFlags>=0.6
+    Flask-Compress>=1.4
+    Flask-Limiter>=0.9.4
+    flask-profiler>=1.0.1
+    Flask-Caching>=1.4.0
+    Flask-Login>=0.4.1
+    Flask-Cors>=3.0.8
+    Flask-Session>=0.3.1
+    redis>=3.3
     #uwsgi>=2.0.15  # install with "conda install -c conda-forge uwsgi" instead
     # added for rtd issues
-    validators>=0.10.3,<1.0
-    intervals>=0.8.0,<1.0
+    validators>=0.10.3
+    intervals>=0.8.0
 db=
-    pgpasslib>=1.1.0,<2.0
-    psycopg2>=2.6.2,<3.0
-    Flask-Login>=0.4.1,<1.0
-    sqlalchemy>=1.3,<1.4
+    pgpasslib>=1.1.0
+    psycopg2>=2.6.2
+    Flask-Login>=0.4.1
+    sqlalchemy>=1.3,<2.0
 
 
 [bdist_wheel]


### PR DESCRIPTION
This PR bumps the minimum python requirement to python 3.8 and relaxes the upper limit on most package dependencies. 