### PR TITLE
Updating Flask package dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Marvin's Change Log
 - Drop support for py <3.7.  Min. version is py3.8.
 - Updating flask web dependencies: Flask > 2, Jinja2 > 3, werkzeug > 2.0, <2.1
 - Removing pacakged Flask-JSGlue, replacing with custom 0.3.1 version with correct use of `markupsafe`.
+- Pinning miniumum numpy version to 1.20, removing use of `np.int` and `np.float`
+- Switch to `packaging.version.parse` from `distutils` for version checking
 
 [2.7.4] - 2022/07/27
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Marvin's Change Log
 [2.8.0] - unreleased
 --------------------
 - Drop support for py <3.7.  Min. version is py3.8.
+- Updating flask web dependencies: Flask > 2, Jinja2 > 3, werkzeug > 2.0, <2.1
+- Removing pacakged Flask-JSGlue, replacing with custom 0.3.1 version with correct use of `markupsafe`.
 
 [2.7.4] - 2022/07/27
 --------------------

--- a/python/marvin/tools/maps.py
+++ b/python/marvin/tools/maps.py
@@ -21,7 +21,7 @@ import astropy.wcs
 import numpy as np
 import pandas as pd
 import six
-from pkg_resources import parse_version
+#from pkg_resources import parse_version
 
 import marvin
 import marvin.api.api
@@ -285,7 +285,6 @@ class Maps(MarvinToolsClass, NSAMixIn, DAPallMixIn, GetApertureMixIn):
             header_bintype = self.data[0].header['BINTYPE'].strip().upper()
 
         # Checks the template from the header
-        #is_MPL8 = parse_version(self._dapver) >= parse_version(datamodel['MPL-8'].release)
         is_MPL8 = check_versions(self._dapver, datamodel['MPL-8'].release)
         header_template_key = 'TPLKEY' if is_MPL4 else 'DAPTYPE' if is_MPL8 else 'SCKEY'
         if is_MPL8:

--- a/python/marvin/tools/mixins/dapall.py
+++ b/python/marvin/tools/mixins/dapall.py
@@ -9,8 +9,8 @@
 # @Last modified by: José Sánchez-Gallego (gallegoj@uw.edu)
 # @Last modified time: 2018-11-14 12:03:58
 
-import distutils
 import os
+from packaging.version import parse
 
 import astropy.io.fits
 
@@ -35,14 +35,14 @@ class DAPallMixIn(object):
 
     """
 
-    __min_dapall_version__ = distutils.version.StrictVersion('2.1.0')
+    __min_dapall_version__ = parse('2.1.0')
 
     @property
     def dapall(self):
         """Returns the contents of the DAPall data for this target."""
 
         if (not self._dapver or
-                distutils.version.StrictVersion(self._dapver) < self.__min_dapall_version__):
+                parse(self._dapver) < self.__min_dapall_version__):
             raise MarvinError('DAPall is not available for versions before MPL-6.')
 
         if hasattr(self, '_dapall') and self._dapall is not None:

--- a/python/marvin/tools/modelcube.py
+++ b/python/marvin/tools/modelcube.py
@@ -12,11 +12,11 @@
 
 from __future__ import absolute_import, division, print_function
 
-import distutils
 import warnings
 
 import numpy as np
-from pkg_resources import parse_version
+from packaging.version import parse
+
 from astropy.io import fits
 from astropy.wcs import WCS
 
@@ -88,8 +88,8 @@ class ModelCube(MarvinToolsClass, NSAMixIn, DAPallMixIn, GetApertureMixIn):
         NSAMixIn.__init__(self, nsa_source=nsa_source)
 
         # Checks that DAP is at least MPL-5
-        MPL5 = distutils.version.StrictVersion('2.0.2')
-        if self.filename is None and distutils.version.StrictVersion(self._dapver) < MPL5:
+        MPL5 = parse('2.0.2')
+        if self.filename is None and parse(self._dapver) < MPL5:
             raise MarvinError('ModelCube requires at least dapver=\'2.0.2\'')
 
         self.header = None
@@ -509,8 +509,7 @@ class ModelCube(MarvinToolsClass, NSAMixIn, DAPallMixIn, GetApertureMixIn):
 
         # Before MPL-6, the modelcube does not include the binid extension,
         # so we need to get the binid map from the associated MAPS.
-        if (distutils.version.StrictVersion(self._dapver) <
-                distutils.version.StrictVersion('2.1')):
+        if (parse(self._dapver) < parse('2.1')):
             return self.getMaps().get_binid()
 
         if self.data_origin == 'file':

--- a/python/marvin/tools/modelcube.py
+++ b/python/marvin/tools/modelcube.py
@@ -277,8 +277,8 @@ class ModelCube(MarvinToolsClass, NSAMixIn, DAPallMixIn, GetApertureMixIn):
 
             self.header = self.data.file.primary_header
             self.wcs = WCS(self.data.file.cube.wcs.makeHeader())
-            self._wavelength = np.array(self.data.file.cube.wavelength.wavelength, dtype=np.float)
-            self._redcorr = np.array(self.data.redcorr[0].value, dtype=np.float)
+            self._wavelength = np.array(self.data.file.cube.wavelength.wavelength, dtype=float)
+            self._redcorr = np.array(self.data.redcorr[0].value, dtype=float)
             self._shape = self.data.file.cube.shape.shape
 
             self.plateifu = str(self.header['PLATEIFU'].strip())

--- a/python/marvin/utils/datamodel/query/forms.py
+++ b/python/marvin/utils/datamodel/query/forms.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm.attributes import InstrumentedAttribute
 from wtforms import Field, SelectMultipleField, StringField, SubmitField, ValidationError, validators
 from wtforms.widgets import TextInput
 from wtforms_alchemy import model_form_factory
+from flask import Markup
 from marvin import config, marvindb
 from marvin.core.exceptions import MarvinUserWarning
 from marvin.utils.general.structs import FuzzyDict
@@ -369,7 +370,7 @@ class ValidOperand(object):
 class SearchForm(Form):
     ''' Main Search Level WTForm for Marvin '''
 
-    url = ("<a target='_blank' data-toggle='tooltip' title='Click to read more about Queries' "
+    url = Markup("<a target='_blank' data-toggle='tooltip' title='Click to read more about Queries' "
            "href='https://sdss-marvin.readthedocs.io/en/stable/query/query/query_using.html'>Input Search Filter</a>")
     searchbox = StringField(url,
                             [validators.Length(min=3, message='Input must have at least 3 characters'),

--- a/python/marvin/utils/general/general.py
+++ b/python/marvin/utils/general/general.py
@@ -22,7 +22,8 @@ import warnings
 from builtins import range
 from collections import OrderedDict
 from functools import wraps
-from pkg_resources import parse_version
+#from pkg_resources import parse_version
+from packaging.version import parse
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -171,7 +172,7 @@ def getSpaxel(cube=True, maps=True, modelcube=True,
         isScalar = np.isscalar(x)
         x = np.atleast_1d(x)
         y = np.atleast_1d(y)
-        coords = np.array([x, y], np.float).T
+        coords = np.array([x, y], float).T
 
     elif ra is not None or dec is not None:
         assert x is None and y is None, 'Either use (x, y) or (ra, dec)'
@@ -181,7 +182,7 @@ def getSpaxel(cube=True, maps=True, modelcube=True,
         isScalar = np.isscalar(ra)
         ra = np.atleast_1d(ra)
         dec = np.atleast_1d(dec)
-        coords = np.array([ra, dec], np.float).T
+        coords = np.array([ra, dec], float).T
 
     else:
         raise ValueError('You need to specify either (x, y) or (ra, dec)')
@@ -263,7 +264,7 @@ def convertCoords(coords, mode='sky', wcs=None, xyorig='center', shape=None):
         coordsSpec = np.ones((coords.shape[0], 3), np.float32)
         coordsSpec[:, :-1] = coords
         cubeCoords = wcs.wcs_world2pix(coordsSpec, 0)
-        cubeCoords = np.fliplr(np.array(np.round(cubeCoords[:, :-1]), np.int))
+        cubeCoords = np.fliplr(np.array(np.round(cubeCoords[:, :-1]), int))
 
     elif mode in ['pix', 'pixel']:
         assert xyorig, 'if mode==pix, xyorig must be defined.'
@@ -283,7 +284,7 @@ def convertCoords(coords, mode='sky', wcs=None, xyorig='center', shape=None):
         else:
             raise ValueError('xyorig must be center or lower.')
 
-        cubeCoords = np.array([yCube, xCube], np.int).T
+        cubeCoords = np.array([yCube, xCube], int).T
 
     else:
         raise ValueError('mode must be pix or sky.')
@@ -1852,7 +1853,7 @@ def check_versions(version1, version2):
         A boolean indicating if version1 is >= version2
     '''
 
-    return parse_version(version1) >= parse_version(version2)
+    return parse(version1) >= parse(version2)
 
 
 def get_manga_image(cube=None, drpver=None, plate=None, ifu=None, dir3d=None, local=None, public=None):

--- a/python/marvin/web/__init__.py
+++ b/python/marvin/web/__init__.py
@@ -8,7 +8,7 @@ from __future__ import print_function, division
 import os
 # Flask imports
 from flask import Flask, Blueprint, send_from_directory, request
-import flask_jsglue as jsg
+from marvin.web import flask_jsglue as jsg
 # Marvin imports
 from brain.utils.general.general import getDbMachine
 from marvin import config, log

--- a/python/marvin/web/controllers/galaxy.py
+++ b/python/marvin/web/controllers/galaxy.py
@@ -279,7 +279,7 @@ def remove_nans(datadict):
         if key != 'plateifu':
             naninds = np.where(np.isnan(vals))[0]
             allnans = np.append(allnans, naninds)
-    allnans = list(set(allnans.astype(np.int)))
+    allnans = list(set(allnans.astype(int)))
     # delete those targets from all items in the dictionary
     for key, vals in datadict.items():
         datadict[key] = np.delete(np.asarray(vals), allnans).tolist()
@@ -295,7 +295,7 @@ def create_vacdata(mangaid: str, release: str = None) -> dict:
     Parameters
     ----------
     mangaid : str
-        The target mangaid 
+        The target mangaid
     release : str
         The data release to use
 
@@ -327,15 +327,15 @@ def create_vacdata(mangaid: str, release: str = None) -> dict:
         if isinstance(v[i], dict):
             for k, j in v[i].items():
                 link = j._rsync.url('', full=j._path)
-                vacdata.append({'name': f'<a target="_blank" href="{j.url}">{j.display_name}: {k}</a>', 
-                                'py': f'cube.vacs.{j.name}[{k}]', 'data': dd[i][k], 
+                vacdata.append({'name': f'<a target="_blank" href="{j.url}">{j.display_name}: {k}</a>',
+                                'py': f'cube.vacs.{j.name}[{k}]', 'data': dd[i][k],
                                 'link': f'<a href="{link}">link</a>'})
         else:
             link = v[i]._rsync.url('', full=v[i]._path)
             vacdata.append({'name': f'<a target="_blank" href="{v[i].url}">{v[i].display_name}</a>',
-                            'py': f'cube.vacs.{v[i].name}', 'data': dd[i], 
+                            'py': f'cube.vacs.{v[i].name}', 'data': dd[i],
                             'link': f'<a href="{link}">link</a>'})
-    return vacdata        
+    return vacdata
 
 
 class Galaxy(BaseWebView):
@@ -439,7 +439,7 @@ class Galaxy(BaseWebView):
                 daplist = [p.full(web=True) for p in dm.properties]
                 dapdefaults = dm.get_default_mapset()
                 self.galaxy['cube'] = cube
-                self.galaxy['vacdata'] = create_vacdata(cube.mangaid, release=self._release)             
+                self.galaxy['vacdata'] = create_vacdata(cube.mangaid, release=self._release)
                 self.galaxy['toggleon'] = current_session.get('toggleon', 'false')
                 self.galaxy['cubehdr'] = cube.header
                 self.galaxy['quality'] = ('DRP3QUAL', cube.quality_flag.mask, cube.quality_flag.labels)

--- a/python/marvin/web/extensions.py
+++ b/python/marvin/web/extensions.py
@@ -20,7 +20,7 @@ from flask_login import LoginManager
 from flask_jwt_extended import JWTManager
 from flask_cors import CORS
 from flask_session import Session
-import flask_jsglue as jsg
+from marvin.web import flask_jsglue as jsg
 import logging
 
 # JS Glue (allows use of Flask.url_for inside javascript)

--- a/python/marvin/web/flask_jsglue.py
+++ b/python/marvin/web/flask_jsglue.py
@@ -1,0 +1,129 @@
+from flask import make_response, url_for
+from markupsafe import Markup
+import re, json
+
+JSGLUE_JS_PATH = '/jsglue.js'
+JSGLUE_NAMESPACE = 'Flask'
+rule_parser = re.compile(r'<(.+?)>')
+splitter = re.compile(r'<.+?>')
+
+
+def get_routes(app):
+    output = []
+    for r in app.url_map.iter_rules():
+        endpoint = r.endpoint
+        rule = r.rule
+        rule_args = [x.split(':')[-1] for x in rule_parser.findall(rule)]
+        rule_tr = splitter.split(rule)
+        output.append((endpoint, rule_tr, rule_args))
+    return sorted(output, key=lambda x: len(x[1]), reverse=True)
+
+
+class JSGlue(object):
+    def __init__(self, app=None, **kwargs):
+        self.app = app
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        self.app = app
+
+        @app.route(JSGLUE_JS_PATH)
+        def serve_js():
+            return make_response(
+                (self.generate_js(), 200, {'Content-Type': 'text/javascript'})
+            )
+
+        @app.context_processor
+        def context_processor():
+            return {'JSGlue': JSGlue}
+
+    def generate_js(self):
+        rules = get_routes(self.app)
+        return """
+var %s = new (function(){
+    'use strict';
+    return {
+        '_endpoints': %s,
+        'url_for': function(endpoint, rule) {
+            if(typeof rule === "undefined") rule = {};
+
+            var has_everything = false, url = "";
+
+            var is_absolute = false, has_anchor = false, has_scheme;
+            var anchor = "", scheme = "";
+
+            if(rule['_external'] === true) {
+                is_absolute = true;
+                scheme = location.protocol.split(':')[0];
+                delete rule['_external'];
+            }
+
+            if('_scheme' in rule) {
+                if(is_absolute) {
+                    scheme = rule['_scheme'];
+                    delete rule['_scheme'];
+                } else {
+                    throw {name:"ValueError", message:"_scheme is set without _external."};
+                }
+            }
+
+            if('_anchor' in rule) {
+                has_anchor = true;
+                anchor = rule['_anchor'];
+                delete rule['_anchor'];
+            }
+
+            for(var i in this._endpoints) {
+                if(endpoint == this._endpoints[i][0]) {
+                    var url = '';
+                    var j = 0;
+                    var has_everything = true;
+                    var used = {};
+                    for(var j = 0; j < this._endpoints[i][2].length; j++) {
+                        var t = rule[this._endpoints[i][2][j]];
+                        if(typeof t === "undefined") {
+                            has_everything = false;
+                            break;
+                        }
+                        url += this._endpoints[i][1][j] + t;
+                        used[this._endpoints[i][2][j]] = true;
+                    }
+                    if(has_everything) {
+                        if(this._endpoints[i][2].length != this._endpoints[i][1].length)
+                            url += this._endpoints[i][1][j];
+
+                        var first = true;
+                        for(var r in rule) {
+                            if(r[0] != '_' && !(r in used)) {
+                                if(first) {
+                                    url += '?';
+                                    first = false;
+                                } else {
+                                    url += '&';
+                                }
+                                url += r + '=' + rule[r];
+                            }
+                        }
+                        if(has_anchor) {
+                            url += "#" + anchor;
+                        }
+
+                        if(is_absolute) {
+                            return scheme + "://" + location.host + url;
+                        } else {
+                            return url;
+                        }
+                    }
+                }
+            }
+
+            throw {name: 'BuildError', message: "Couldn't find the matching endpoint."};
+        }
+    };
+});""" % (JSGLUE_NAMESPACE, json.dumps(rules))
+
+    @staticmethod
+    def include():
+        js_path = url_for('serve_js')
+        return Markup('<script src="%s" type="text/javascript"></script>') % (js_path,)

--- a/python/marvin/web/jinja_filters.py
+++ b/python/marvin/web/jinja_filters.py
@@ -23,7 +23,7 @@ jinjablue = flask.Blueprint('jinja_filters', __name__)
 # Ref: http://stackoverflow.com/questions/12288454/how-to-import-custom-jinja2-filters-from-another-file-and-using-flask
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 @jinjablue.app_template_filter()
 def make_token(context, value, group):
     ''' Make a keyword string for query parameter dropdown live search '''
@@ -31,7 +31,7 @@ def make_token(context, value, group):
     return tokstring
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 @jinjablue.app_template_filter()
 def filtergaltype(context, value):
     ''' Parse plateifu or mangaid into better form '''
@@ -41,7 +41,7 @@ def filtergaltype(context, value):
         return 'MaNGA-ID'
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 @jinjablue.app_template_filter()
 def filternsa(context, value):
     ''' Parse plateifu or mangaid into better form '''
@@ -52,7 +52,7 @@ def filternsa(context, value):
     return newvalue
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 @jinjablue.app_template_filter()
 def filternsaval(context, value, key):
     ''' Parse plateifu or mangaid into better form '''
@@ -67,7 +67,7 @@ def filternsaval(context, value, key):
     return newvalue
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 @jinjablue.app_template_filter()
 def allclose(context, value, newvalue):
     ''' Do a numpy allclose comparison between the two values '''
@@ -77,7 +77,7 @@ def allclose(context, value, newvalue):
         return False
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 @jinjablue.app_template_filter()
 def prettyFlag(context, value):
     ''' Pretty print bit mask and flags '''
@@ -85,7 +85,7 @@ def prettyFlag(context, value):
     return '{0}: {1} - {2}'.format(name, bit, ', '.join(flags))
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 @jinjablue.app_template_filter()
 def qaclass(context, value):
     ''' Return an alert indicator based on quality flags '''
@@ -97,7 +97,7 @@ def qaclass(context, value):
     return out, text
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 @jinjablue.app_template_filter()
 def targtype(context, value):
     ''' Return the MaNGA target type based on what bit is set '''
@@ -108,7 +108,7 @@ def targtype(context, value):
     return out
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 @jinjablue.app_template_filter()
 def split(context, value, delim=None):
     '''Split a string based on a delimiter'''
@@ -117,7 +117,7 @@ def split(context, value, delim=None):
     return value.split(delim) if value else None
 
 
-@jinja2.contextfilter
+@jinja2.pass_context
 @jinjablue.app_template_filter()
 def striprelease(context, value):
     '''Strip and trim and lowercase a release string'''

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,8 +55,8 @@ install_requires =
     raven>=5.32.0,<7.0
     packaging>=20.1,<21.0
     yamlordereddictloader>=0.2.2
-    markupsafe<2.1
     # numerical
+    numpy>1.20
     scipy>=0.18.1
     # plotting
     pandas>=1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ install_requires =
     matplotlib>=1.5.3
     # api / web
     webargs>=1.5.2,<6.0
+    werkzeug>=2.0,<2.1
     Flask-JWT-Extended>=3.8.1,<4.0
     # database
     dogpile.cache>=0.6.2,<1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -132,7 +132,9 @@ docs =
     ipykernel>5.0
 web=
     blinker>=1.4
-    Flask-JSGlue>=0.3
+    Flask>=2
+    werkzeug>=2,<2.1
+    #Flask-JSGlue>=0.3
     Flask-FeatureFlags>=0.6
     Flask-Compress>=1.4
     Flask-Limiter>=0.9.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -135,7 +135,6 @@ web=
     blinker>=1.4
     Flask>=2
     werkzeug>=2,<2.1
-    #Flask-JSGlue>=0.3
     Flask-FeatureFlags>=0.6
     Flask-Compress>=1.4
     Flask-Limiter>=0.9.4

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -198,7 +198,7 @@ class TestConfig(object):
         assert 'You must have collaboration access to login.' in str(cm.value)
 
     @pytest.mark.parametrize('defrel, exprel',
-                             [('DR20', 'MPL-9'), ('bad_release', 'MPL-9')])
+                             [('DR20', 'MPL-11'), ('bad_release', 'MPL-11')])
     def test_bad_default_release(self, initconfig, defrel, exprel):
         ''' this tests some initial conditions on config '''
         config._release = defrel
@@ -222,7 +222,7 @@ class TestSasUrl(object):
 
     def test_sasurl_nonetrc(self, initconfig, netrc):
         assert 'DR' in config.release
-        assert 'dr15.sdss.org/' in config.sasurl
+        assert 'dr17.sdss.org/' in config.sasurl
 
     @pytest.mark.parametrize('release',
                              [('MPL-6'), ('DR15')],

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -216,6 +216,23 @@ class TestConfig(object):
         assert 'drpall-{0}'.format(drp) in config.drpall
         assert 'dapall-{0}-{1}'.format(drp, dap) in config.dapall
 
+    def test_summary_filepaths(self):
+        config.setRelease("DR17")
+        assert 'sas/dr17' in config.drpall
+        assert 'sas/dr17' in config.dapall
+        config.setRelease("DR15")
+        assert 'sas/dr15' in config.drpall
+        assert 'sas/dr15' in config.dapall
+
+    @pytest.mark.parametrize('name, vers, exp',
+                             [('drpall', ('v3_1_1', None), 'sas/dr17/manga/spectro/redux/v3_1_1'),
+                              ('dapall', ('v3_1_1', '3.1.0'), 'sas/dr17/manga/spectro/analysis/v3_1_1/3.1.0/')],
+                             ids=['drpall', 'dapall'])
+    def test_default_path(self, name, vers, exp):
+        config.setRelease("DR17")
+        drpver, dapver = vers
+        path = config._get_default_path(name, drpver, dapver=dapver)
+        assert exp in path
 
 @pytest.mark.usefixtures('setapi')
 class TestSasUrl(object):


### PR DESCRIPTION
This PR updates the Flask package dependencies to `Flask >2`, `Jinja2 > 3`, `werkzeug > 2.0, < 2.1`.  It removes the pip package `Flask-JSGlue` and replaces it with a manual module of version 0.3.1 with the fixed syntax using the `markupsafe` package.  `Flask-JSGlue` does not appear to be regularly maintained right now.  

It also fixes an issue with `WTForms >3` where a String Field was no longer correctly rendering a url. Wrapping it in `flask.Markup` resolves the issue.   

Pinning numpy to >1.20 and switching use of `np.int` and `np.float` to `int` and `float` to clear deprecation warnings.  Switching use of `distutils` to `packaging.version` to clear deprecation warnings. 
