### PR TITLE
Bump rtd python version

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,7 +4,7 @@ build:
    image: latest
 
 python:
-   version: 3.7
+   version: 3.9
    install:
       - method: pip
         path: .


### PR DESCRIPTION
This PR bumps the readthedocs python build version to 3.9.  
