### PR TITLE
pinning highcharts version

### DIFF
--- a/python/marvin/web/templates/explore.html
+++ b/python/marvin/web/templates/explore.html
@@ -84,12 +84,12 @@
 
 <!-- JS Code -->
 {% block code %}
-<script rel='preconnect' src="https://code.highcharts.com/highcharts.js"></script>
-<script rel='preconnect' src="https://code.highcharts.com/highcharts-more.js"></script>
+<script rel='preconnect' src="https://code.highcharts.com/11.2.0/highcharts.js"></script>
+<script rel='preconnect' src="https://code.highcharts.com/11.2.0/highcharts-more.js"></script>
 <script src="https://cdn.rawgit.com/highcharts/draggable-legend/9c154d4c/draggable-legend.js"></script>
-<script rel='preconnect' src="https://code.highcharts.com/modules/heatmap.js"></script>
-<script rel='preconnect' src="https://code.highcharts.com/modules/exporting.js"></script>
-<script rel='preconnect' src="https://code.highcharts.com/modules/boost.js"></script>
+<script rel='preconnect' src="https://code.highcharts.com/11.2.0/modules/heatmap.js"></script>
+<script rel='preconnect' src="https://code.highcharts.com/11.2.0/modules/exporting.js"></script>
+<script rel='preconnect' src="https://code.highcharts.com/11.2.0/modules/boost.js"></script>
 <script rel='preconnect' src="https://highcharts.github.io/pattern-fill/pattern-fill-v2.js"></script>
 <script rel='preconnect' src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.6.0/math.min.js"></script>
 

--- a/python/marvin/web/templates/galaxy.html
+++ b/python/marvin/web/templates/galaxy.html
@@ -10,12 +10,12 @@
 {% block jshead %}
     <script rel'preconnect' src="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.1.0/dygraph.min.js" integrity="sha256-XT58qJPKCsRBRq+MIcNDQ7dVh0GAa1k2r24w62z0Olk=" crossorigin="anonymous"></script>
     <script rel='preconnect' src="//cdnjs.cloudflare.com/ajax/libs/ol3/3.14.2/ol.min.js"></script>
-    <script rel='preconnect' src="https://code.highcharts.com/highcharts.js"></script>
-    <script rel='preconnect' src="https://code.highcharts.com/highcharts-more.js"></script>
+    <script rel='preconnect' src="https://code.highcharts.com/11.2.0/highcharts.js"></script>
+    <script rel='preconnect' src="https://code.highcharts.com/11.2.0/highcharts-more.js"></script>
     <script src="https://cdn.rawgit.com/highcharts/draggable-legend/9c154d4c/draggable-legend.js"></script>
-    <script rel='preconnect' src="https://code.highcharts.com/modules/heatmap.js"></script>
-    <script rel='preconnect' src="https://code.highcharts.com/modules/exporting.js"></script>
-    <script rel='preconnect' src="https://code.highcharts.com/modules/boost.js"></script>
+    <script rel='preconnect' src="https://code.highcharts.com/11.2.0/modules/heatmap.js"></script>
+    <script rel='preconnect' src="https://code.highcharts.com/11.2.0/modules/exporting.js"></script>
+    <script rel='preconnect' src="https://code.highcharts.com/11.2.0/modules/boost.js"></script>
     <script rel='preconnect' src="https://highcharts.github.io/pattern-fill/pattern-fill-v2.js"></script>
     <script rel='preconnect' src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/3.6.0/math.min.js"></script>
 


### PR DESCRIPTION
Fixes #802.  This update pins the highcharts library to 11.2.0.  The latest 11.3.0 breaks the map display in the web.  We were using the JS url which always pointed to the latest release, instead of a fixed version.  

Also created a `2.7.x` branch from the 2.7.4 tag to be able to continue patching the Utah deployment, which runs on `marvin ~ 2.7` for any future issues.  This branch has diverged from `main` and versions of marvin > 2.8.     
