### PR TITLE
Switch default api server url to JHU

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Marvin's Change Log
 ===================
 
+[2.8.1] - unreleased
+--------------------
+- Made the default API url the "mirror", i.e. point to the new JHU server home.
+- Changed the matplotlib ``seaborn-darkgrid`` style to ``seaborn-v0.8-darkgrid``
+- Fixed `astropy 6` quantity truthiness error in ``marvin.tools.quantities.spectrum``.
+
 [2.8.0] - 2022/08/17
 --------------------
 - Drop support for py <3.7.  Min. version is py3.8.

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -108,7 +108,7 @@ release = marvin_version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 highlight_language = 'default'
 
@@ -386,7 +386,7 @@ GoogleDocstring._parse = patched_parse
 # plot_pre_code = """
 # import matplotlib.pyplot as plt
 
-# plt.style.use(['seaborn-dark', 'seaborn-darkgrid'])
+# plt.style.use(['seaborn-v0_8-dark', 'seaborn-v0_8-darkgrid'])
 # """
 
 # plot_apply_rcparams = False

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -28,8 +28,9 @@ Marvin is a tool specifically designed to visualise and analyse `MaNGA <https://
 
 .. note:: This documentation assumes that you are familiar with MaNGA data and its acronyms. If that is not your case, consider reading `this <https://www.sdss.org/dr16/manga/getting-started/>`_.
 
-.. warning:: Marvin 2.x is the last version that will support Python 2.
-  Marvin 3 and following will require Python 3.6+.
+.. warning:: As of June 2024, the Marvin Web and API have been migrated to a new server home.
+   ``sdss-marvin >= 2.8.2`` has been updated to reflect this change.  Please update to the latest package version.
+   For package versions ``<= 2.8.1``, please see this :ref:`Workaround <marvin-server-workaround>`
 
 
 At a Glance

--- a/docs/sphinx/server_change.rst
+++ b/docs/sphinx/server_change.rst
@@ -1,0 +1,30 @@
+
+.. _marvin-server-workaround:
+
+Quick Note
+----------
+
+As of June 2024, the Marvin Web and API have been migrated to a new server home.  You should see no
+change in the use of the Web, however your use of the Marvin python package will need tweaking.
+
+When accessing files remotely, you may encounter the following error message:
+::
+
+    BrainError: Requests Http Status Error: 409 Client Error: CONFLICT for url: xxx
+    Error: data release None no longer supported by the Marvin API. Update to a later MPL or use Marvin's local file access mode instead.
+
+
+To resolve this issue, please update to ``sdss-marvin >= 2.8.2``, where the recent server changes are
+accounted for.  For package versions ``<= 2.8.1``, use the following workaround:
+
+In your Python session, run the following code::
+
+    from marvin import config
+    config.switchSasUrl(sasmode='mirror')
+
+
+To make this change permanent, create a configuration YAML file at ``~/.marvin/marvin.yml``, add
+the following lines inside:
+::
+    use_mirror: true
+    default_release: dr17

--- a/docs/sphinx/tools/aperture.rst
+++ b/docs/sphinx/tools/aperture.rst
@@ -79,7 +79,7 @@ The following examples shows how to define several types of aperture ::
 Working with masks
 ------------------
 
-`~mixins.aperture.MarvinAperture` objects are thin wraps around the `photutils.Aperture` class and thus provide all the methods and properties of the parent class. A very convenient feature is the ability of using the `photutils.Aperture.to_pixel` and `photutils.Aperture.to_mask` methods to generate a fractional pixel mask of all the apertures. `~mixins.aperture.MarvinAperture.mask` streamlines the process and returns the mask directly ::
+`~mixins.aperture.MarvinAperture` objects are thin wraps around the `photutils.aperture.Aperture` class and thus provide all the methods and properties of the parent class. A very convenient feature is the ability of using the `photutils.aperture.Aperture.to_pixel` and `photutils.aperture.Aperture.to_mask` methods to generate a fractional pixel mask of all the apertures. `~mixins.aperture.MarvinAperture.mask` streamlines the process and returns the mask directly ::
 
         >>> aperture_ell = cube.getAperture([(5, 5), (20, 15)], (4, 3, 0), aperture_type='elliptical')
         >>> aperture_ell.mask

--- a/docs/sphinx/tools/utils/plot-map.rst
+++ b/docs/sphinx/tools/utils/plot-map.rst
@@ -81,7 +81,7 @@ This flexibilty is especially useful for passing in a custom mask, such as one c
     :context: close-figs
 
     import matplotlib.pyplot as plt
-    plt.style.use('seaborn-darkgrid')  # set matplotlib style sheet
+    plt.style.use('seaborn-v0_8-darkgrid')  # set matplotlib style sheet
 
     plateifus = ['8485-1901', '7443-12701']
     mapnames = ['stellar_vel', 'stellar_sigma']

--- a/docs/sphinx/tutorials/exercises/marvin_kinematics_solution.ipynb
+++ b/docs/sphinx/tutorials/exercises/marvin_kinematics_solution.ipynb
@@ -23,7 +23,7 @@
     "import copy\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "plt.style.use('seaborn-darkgrid')\n",
+    "plt.style.use('seaborn-v0_8-darkgrid')\n",
     "%matplotlib inline"
    ]
   },

--- a/docs/sphinx/tutorials/lean-tutorial.rst
+++ b/docs/sphinx/tutorials/lean-tutorial.rst
@@ -109,7 +109,7 @@ Now let's plot the spectrum and model fit:
 
     >>> import matplotlib.pyplot as plt
     >>> # Set matplotlib style sheet. Undo with matplotib.rcdefaults().
-    >>> plt.style.use('seaborn-darkgrid')
+    >>> plt.style.use('seaborn-v0_8-darkgrid')
 
     >>> ax = spax.flux.plot()
     >>> ax.plot(spax.full_fit.wavelength, spax.full_fit.value)
@@ -120,7 +120,7 @@ Now let's plot the spectrum and model fit:
     :include-source: False
 
     >>> import matplotlib.pyplot as plt
-    >>> plt.style.use('seaborn-darkgrid')
+    >>> plt.style.use('seaborn-v0_8-darkgrid')
     >>> from marvin.tools.maps import Maps
     >>> maps = Maps('1-22301')
     >>> spax = maps.getSpaxel(x=28, y=24, xyorig='lower', cube=True, modelcube=True)

--- a/docs/sphinx/tutorials/notebooks/lean-tutorial.ipynb
+++ b/docs/sphinx/tutorials/notebooks/lean-tutorial.ipynb
@@ -188,7 +188,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "# Set matplotlib style sheet. Undo with matplotib.rcdefaults().\n",
-    "plt.style.use('seaborn-darkgrid')"
+    "plt.style.use('seaborn-v0_8-darkgrid')"
    ]
   },
   {

--- a/docs/sphinx/tutorials/plotting-tutorial.rst
+++ b/docs/sphinx/tutorials/plotting-tutorial.rst
@@ -18,7 +18,7 @@ Set Style Sheet
 .. code-block:: python
 
     import matplotlib.pyplot as plt
-    plt.style.use('seaborn-darkgrid')
+    plt.style.use('seaborn-v0_8-darkgrid')
 
 
 Restore Default Style
@@ -137,7 +137,7 @@ This code produces the right panel of Figure 1 from the `Marvin paper
     stsig = maps.stellar_sigma
     stsig_corr = stsig.inst_sigma_correction()
 
-    with plt.style.context('seaborn-darkgrid'):
+    with plt.style.context('seaborn-v0_8-darkgrid'):
         fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(12, 11))
         halpha.plot(fig=fig, ax=axes[0, 0])
         nii_ha.plot(fig=fig, ax=axes[0, 1], title="log([NII]6585 / H-alpha)", snr_min=None)
@@ -161,7 +161,7 @@ Multi-panel Map Plot (Multiple Galaxies)
     plateifus = ['8485-1901', '7443-12701']
     mapnames = ['stellar_vel', 'stellar_sigma']
 
-    with plt.style.context('seaborn-darkgrid'):
+    with plt.style.context('seaborn-v0_8-darkgrid'):
         rows = len(plateifus)
         cols = len(mapnames)
         fig, axes = plt.subplots(rows, cols, figsize=(8, 6))
@@ -315,7 +315,7 @@ Custom Spectrum and Model Fit
 
     import matplotlib.pyplot as plt
     from marvin.tools import Maps
-    plt.style.use('seaborn-darkgrid')
+    plt.style.use('seaborn-v0_8-darkgrid')
 
     maps = Maps('1-209232')
     spax = maps.getSpaxel(x=0, y=0, xyorig='center', cube=True, modelcube=True)

--- a/python/marvin/__init__.py
+++ b/python/marvin/__init__.py
@@ -595,7 +595,7 @@ class MarvinConfig(object):
             allowed = {k: v for k, v in allowed.items() if k in web_releases or 'DR' in k}
         return allowed
 
-    def switchSasUrl(self, sasmode='utah', ngrokid=None, port=5000, test=False,
+    def switchSasUrl(self, sasmode='mirror', ngrokid=None, port=5000, test=False,
                      base=None, public=None):
         ''' Switches the API SAS url config attribute
 
@@ -729,9 +729,9 @@ class MarvinConfig(object):
 
         # switch the API url depending on release
         if 'MPL' in value:
-            self.switchSasUrl('utah')
+            self.switchSasUrl('mirror')
         elif 'DR' in value:
-            self.switchSasUrl('utah', public=True)
+            self.switchSasUrl('mirror', public=True)
 
         # check to use the SAS mirror
         mirror = self._custom_config.get('use_mirror', None)

--- a/python/marvin/tools/mixins/aperture.py
+++ b/python/marvin/tools/mixins/aperture.py
@@ -15,19 +15,19 @@ import numpy
 
 
 try:
-    import photutils
+    from photutils import aperture
 except ImportError:
-    photutils = None
+    aperture = None
 
 
 __all__ = ['GetApertureMixIn', 'MarvinAperture']
 
 
-class MarvinAperture(photutils.Aperture if photutils else object):
-    """Extends `photutils.Aperture` allowing to extract spaxels in the aperture.
+class MarvinAperture(aperture.Aperture if aperture.Aperture else object):
+    """Extends `photutils.aperture.Aperture` allowing to extract spaxels in the aperture.
 
     This class is not intended for general use and it is dynamically set as
-    the base for a `~photutils.Aperture` instance.
+    the base for a `~photutils.aperture.Aperture` instance.
 
     """
 
@@ -49,15 +49,15 @@ class MarvinAperture(photutils.Aperture if photutils else object):
     def mask(self):
         """Returns the fractional overlap mask.
 
-        Equivalent to using `photutils.PixelAperture.to_mask` followed
-        by `photutils.ApertureMask.to_image` using the shape of the parent
+        Equivalent to using `photutils.aperture.PixelAperture.to_mask` followed
+        by `photutils.aperture.ApertureMask.to_image` using the shape of the parent
         object. Combines all the apertures in a single mask.
 
         """
 
         assert self.parent is not None, 'no parent set'
 
-        if isinstance(self, photutils.SkyAperture):
+        if isinstance(self, aperture.SkyAperture):
             aperture = self.to_pixel(self.parent.wcs)
         else:
             aperture = self
@@ -198,7 +198,7 @@ class GetApertureMixIn(object):
 
         """
 
-        if photutils is None:
+        if aperture is None:
             raise ImportError('this feature requires photutils. Install it by '
                               'doing pip install photutils.')
 
@@ -215,19 +215,19 @@ class GetApertureMixIn(object):
 
         if aperture_type == 'circular':
             if coord_type == 'pixel':
-                ApertureClass = photutils.CircularAperture
+                ApertureClass = aperture.CircularAperture
             else:
-                ApertureClass = photutils.SkyCircularAperture
+                ApertureClass = aperture.SkyCircularAperture
         elif aperture_type == 'elliptical':
             if coord_type == 'pixel':
-                ApertureClass = photutils.EllipticalAperture
+                ApertureClass = aperture.EllipticalAperture
             else:
-                ApertureClass = photutils.SkyEllipticalAperture
+                ApertureClass = aperture.SkyEllipticalAperture
         elif aperture_type == 'rectangular':
             if coord_type == 'pixel':
-                ApertureClass = photutils.RectangularAperture
+                ApertureClass = aperture.RectangularAperture
             else:
-                ApertureClass = photutils.SkyRectangularAperture
+                ApertureClass = aperture.SkyRectangularAperture
         else:
             raise ValueError('invalid aperture_type')
 

--- a/python/marvin/tools/mixins/aperture.py
+++ b/python/marvin/tools/mixins/aperture.py
@@ -15,15 +15,15 @@ import numpy
 
 
 try:
-    from photutils import aperture
+    import photutils.aperture as pap
 except ImportError:
-    aperture = None
+    pap = None
 
 
 __all__ = ['GetApertureMixIn', 'MarvinAperture']
 
 
-class MarvinAperture(aperture.Aperture if aperture.Aperture else object):
+class MarvinAperture(pap.Aperture if pap.Aperture else object):
     """Extends `photutils.aperture.Aperture` allowing to extract spaxels in the aperture.
 
     This class is not intended for general use and it is dynamically set as
@@ -57,7 +57,7 @@ class MarvinAperture(aperture.Aperture if aperture.Aperture else object):
 
         assert self.parent is not None, 'no parent set'
 
-        if isinstance(self, aperture.SkyAperture):
+        if isinstance(self, pap.SkyAperture):
             aperture = self.to_pixel(self.parent.wcs)
         else:
             aperture = self
@@ -198,7 +198,7 @@ class GetApertureMixIn(object):
 
         """
 
-        if aperture is None:
+        if pap is None:
             raise ImportError('this feature requires photutils. Install it by '
                               'doing pip install photutils.')
 
@@ -215,19 +215,19 @@ class GetApertureMixIn(object):
 
         if aperture_type == 'circular':
             if coord_type == 'pixel':
-                ApertureClass = aperture.CircularAperture
+                ApertureClass = pap.CircularAperture
             else:
-                ApertureClass = aperture.SkyCircularAperture
+                ApertureClass = pap.SkyCircularAperture
         elif aperture_type == 'elliptical':
             if coord_type == 'pixel':
-                ApertureClass = aperture.EllipticalAperture
+                ApertureClass = pap.EllipticalAperture
             else:
-                ApertureClass = aperture.SkyEllipticalAperture
+                ApertureClass = pap.SkyEllipticalAperture
         elif aperture_type == 'rectangular':
             if coord_type == 'pixel':
-                ApertureClass = aperture.RectangularAperture
+                ApertureClass = pap.RectangularAperture
             else:
-                ApertureClass = aperture.SkyRectangularAperture
+                ApertureClass = pap.SkyRectangularAperture
         else:
             raise ValueError('invalid aperture_type')
 

--- a/python/marvin/tools/quantities/spectrum.py
+++ b/python/marvin/tools/quantities/spectrum.py
@@ -124,7 +124,7 @@ class Spectrum(Quantity, QuantityMixIn):
 
     def plot(self, xlim=None, ylim=None, show_std=True, use_mask=True,
              n_sigma=1, xlabel='Wavelength', ylabel='Flux', show_units=True,
-             plt_style='seaborn-darkgrid', figure=None, return_figure=False,
+             plt_style='seaborn-v0_8-darkgrid', figure=None, return_figure=False,
              title=None, ytrim='positive', **kwargs):
         """Plots the spectrum.
 
@@ -162,7 +162,7 @@ class Spectrum(Quantity, QuantityMixIn):
             title (str):
                 The title of the plot
             plt_style (str):
-                Matplotlib style sheet to use. Default is 'seaborn-darkgrid'.
+                Matplotlib style sheet to use. Default is 'seaborn-v0_8-darkgrid'.
             figure (`~matplotlib.figure.Figure` or None):
                 The matplotlib `~matplotlib.figure.Figure` object from which
                 the axes must be created. If ``figure=None``, a new figure will

--- a/python/marvin/tools/quantities/spectrum.py
+++ b/python/marvin/tools/quantities/spectrum.py
@@ -203,11 +203,11 @@ class Spectrum(Quantity, QuantityMixIn):
             donotuse_mask = self.pixmask.get_mask('DONOTUSE') > 0
             value = self.masked
             wave = np.ma.array(self.wavelength.value, mask=donotuse_mask)
-            std = self.std.value if self.std else None
+            std = self.std.value if self.std is not None else None
         else:
             value = self.value
             wave = self.wavelength.value
-            std = self.std.value if self.std else None
+            std = self.std.value if self.std is not None else None
 
         ax.plot(wave, value, **kwargs)
 

--- a/python/marvin/utils/dap/bpt.py
+++ b/python/marvin/utils/dap/bpt.py
@@ -366,7 +366,7 @@ def bpt_kewley06(maps, snr_min=3, return_figure=True, use_oi=True, **kwargs):
         return bpt_return_classification
 
     # Does all the plotting
-    with plt.style.context('seaborn-darkgrid'):
+    with plt.style.context('seaborn-v0_8-darkgrid'):
         fig, grid_bpt, gal_bpt = _get_kewley06_axes(use_oi=use_oi)
 
     sf_kwargs = {'marker': 's', 's': 12, 'color': 'c', 'zorder': 50, 'alpha': 0.7, 'lw': 0.0,

--- a/python/marvin/utils/datamodel/query/base.py
+++ b/python/marvin/utils/datamodel/query/base.py
@@ -142,7 +142,7 @@ class QueryDataModel(object):
         # make the call
         if url:
             try:
-                ii = Interaction(url, params={'release': self.release, 'paramdisplay': 'all'}, base=bconfig._collab_api_url)
+                ii = Interaction(url, params={'release': self.release, 'paramdisplay': 'all'}, base=bconfig.mirror_api_url)
             except Exception as e:
                 warnings.warn('Could not remotely retrieve full set of parameters. {0}'.format(e), MarvinUserWarning)
                 self._keys = []

--- a/python/marvin/utils/plot/map.py
+++ b/python/marvin/utils/plot/map.py
@@ -335,7 +335,7 @@ def plot(*args, **kwargs):
             Otherwise provide a mask name as a string or multiple mask names as
             a list of strings. Default is ``True``.
         plt_style (str):
-            Matplotlib style sheet to use. Default is 'seaborn-darkgrid'.
+            Matplotlib style sheet to use. Default is 'seaborn-v0_8-darkgrid'.
         fig (matplotlib Figure object):
             Use if creating subplot of a multi-panel plot. Default is ``None``.
         ax (matplotlib Axis object):
@@ -394,7 +394,7 @@ def plot(*args, **kwargs):
     cblabel = kwargs.get('cblabel', None)
     sky_coords = kwargs.get('sky_coords', False)
     use_masks = kwargs.get('use_masks', True)
-    plt_style = kwargs.get('plt_style', 'seaborn-darkgrid')
+    plt_style = kwargs.get('plt_style', 'seaborn-v0_8-darkgrid')
     fig = kwargs.get('fig', None)
     ax = kwargs.get('ax', None)
     patch_kws = kwargs.get('patch_kws', {})

--- a/python/marvin/utils/plot/scatter.py
+++ b/python/marvin/utils/plot/scatter.py
@@ -363,7 +363,7 @@ def plot(x, y, **kwargs):
     use_density = True if count > 500000 else False
 
     # create figure and axes objects
-    with plt.style.context('seaborn-darkgrid'):
+    with plt.style.context('seaborn-v0_8-darkgrid'):
         fig, ax_scat, ax_hist_x, ax_hist_y = _create_figure(hist=with_hist, use_density=use_density,
                                                             hist_axes_visible=hist_axes_visible)
 
@@ -514,7 +514,7 @@ def hist(arr, mask=None, fig=None, ax=None, bins=None, **kwargs):
     orientation = kwargs.pop('orientation', 'vertical')
 
     # create a figure and axis if they don't exist
-    with plt.style.context('seaborn-darkgrid'):
+    with plt.style.context('seaborn-v0_8-darkgrid'):
         if fig is None and ax is None:
             fig, ax = plt.subplots()
         elif fig is None:
@@ -559,7 +559,3 @@ def hist(arr, mask=None, fig=None, ax=None, bins=None, **kwargs):
 
     output = (hist_data, fig, ax) if return_figure else hist_data
     return output
-
-
-
-

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -315,6 +315,3 @@ class TestLogin(object):
         assert config.token is None
         config.login()
         assert config.token is not None
-
-
-


### PR DESCRIPTION
This PR closes #811 and makes the default API url point to the new JHU server home of ``magrathea.sdss.org``.   This option was already present but now the ``config.sasurl`` is forced to always point there.  

It also changes the ``matplotlib`` plot style from ``seaborn-darkgrid`` to ``seaborn-v0.8-darkgrid``.  See https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.6.0.html#seaborn-styles-renamed. 

It also changes the `photutils` syntax from `photutils.Aperture` to `photutils.aperture.Aperture` to avoid deprecation. 